### PR TITLE
build(deps): bump gradle from 3.5.3 to 3.6.2 in /demo-java

### DIFF
--- a/demo-java/build.gradle
+++ b/demo-java/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.6.2'
     }
 }
 

--- a/demo-java/gradle/wrapper/gradle-wrapper.properties
+++ b/demo-java/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip


### PR DESCRIPTION
Addressing build failure on #51.
