### PR TITLE
chore: Demo using buildConfigValue to pass in API key.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 *.iml
 local.properties
 .DS_Store
+secure.properties

--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ In Android Studio, use the "Open an existing Android Studio project", and select
 
 Alternatively use the `./gradlew build` command to build the project directly.
 
-Don't forget to add your API key to the `gradle.properties` file for each demo.
+The demos also require that you add your own API key:
+1. [Get an API Key](https://developers.google.com/places/android-sdk/get-api-key).
+2. Create a file in the root directory called `secure.properties` (this file should _NOT_ be under version control to protect your API key).
+3. Add a single line to `secure.properties` that looks like `PLACES_API_KEY=YOUR_API_KEY`, where `YOUR_API_KEY` is the API key you obtained in the first step. You can also take a look at `secure.properties.template` as an example.
+4. Build and run.
 
 Support
 -------

--- a/demo-java/app/build.gradle
+++ b/demo-java/app/build.gradle
@@ -11,7 +11,18 @@ android {
         multiDexEnabled true
         versionCode 1
         versionName "1.0"
-        resValue "string", "places_api_key", (project.findProperty("PLACES_API_KEY") ?: "")
+
+        // Read the API key from ./secure.properties into R.string.maps_api_key
+        def secureProps = new Properties()
+        if (file("../../secure.properties").exists()) {
+            file("../../secure.properties")?.withInputStream { secureProps.load(it) }
+        }
+        buildConfigField("String", "PLACES_API_KEY", (secureProps.getProperty("PLACES_API_KEY") ?: ""))
+
+        // To add your Maps API key to this project:
+        // 1. Create a file ./secure.properties
+        // 2. Add this line, where YOUR_API_KEY is your API key:
+        //        PLACES_API_KEY=YOUR_API_KEY
     }
     buildTypes {
         release {

--- a/demo-java/app/build.gradle
+++ b/demo-java/app/build.gradle
@@ -17,7 +17,7 @@ android {
         if (file("../../secure.properties").exists()) {
             file("../../secure.properties")?.withInputStream { secureProps.load(it) }
         }
-        buildConfigField("String", "PLACES_API_KEY", (secureProps.getProperty("PLACES_API_KEY") ?: ""))
+        buildConfigField("String", "PLACES_API_KEY", (secureProps.getProperty("PLACES_API_KEY") ?: "\"\""))
 
         // To add your Maps API key to this project:
         // 1. Create a file ./secure.properties

--- a/demo-java/app/src/gms/java/com/example/placesdemo/MainActivity.java
+++ b/demo-java/app/src/gms/java/com/example/placesdemo/MainActivity.java
@@ -41,7 +41,7 @@ public class MainActivity extends AppCompatActivity {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
 
-    String apiKey = getString(R.string.places_api_key);
+    final String apiKey = BuildConfig.PLACES_API_KEY;
 
     if (apiKey.equals("")) {
       Toast.makeText(this, getString(R.string.error_api_key), Toast.LENGTH_LONG).show();

--- a/demo-java/app/src/gms/java/com/example/placesdemo/programmatic_autocomplete/ProgrammaticAutocompleteToolbarActivity.java
+++ b/demo-java/app/src/gms/java/com/example/placesdemo/programmatic_autocomplete/ProgrammaticAutocompleteToolbarActivity.java
@@ -34,6 +34,7 @@ import com.android.volley.Request.Method;
 import com.android.volley.RequestQueue;
 import com.android.volley.toolbox.JsonObjectRequest;
 import com.android.volley.toolbox.Volley;
+import com.example.placesdemo.BuildConfig;
 import com.example.placesdemo.MainActivity;
 import com.example.placesdemo.R;
 import com.example.placesdemo.model.GeocodingResult;
@@ -202,7 +203,7 @@ public class ProgrammaticAutocompleteToolbarActivity extends AppCompatActivity {
      */
     private void geocodePlaceAndDisplay(AutocompletePrediction placePrediction) {
         // Construct the request URL
-        final String apiKey = getString(R.string.places_api_key);
+        final String apiKey = BuildConfig.PLACES_API_KEY;
         final String url = "https://maps.googleapis.com/maps/api/geocode/json?place_id=%s&key=%s";
         final String requestURL = String.format(url, placePrediction.getPlaceId(), apiKey);
 

--- a/demo-java/app/src/v3/java/com/example/placesdemo/MainActivity.java
+++ b/demo-java/app/src/v3/java/com/example/placesdemo/MainActivity.java
@@ -48,7 +48,7 @@ public class MainActivity extends AppCompatActivity {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
 
-    String apiKey = getString(R.string.places_api_key);
+    final String apiKey = BuildConfig.PLACES_API_KEY;
 
     if (apiKey.equals("")) {
       Toast.makeText(this, getString(R.string.error_api_key), Toast.LENGTH_LONG).show();

--- a/demo-java/app/src/v3/java/com/example/placesdemo/programmatic_autocomplete/ProgrammaticAutocompleteToolbarActivity.java
+++ b/demo-java/app/src/v3/java/com/example/placesdemo/programmatic_autocomplete/ProgrammaticAutocompleteToolbarActivity.java
@@ -41,6 +41,7 @@ import com.android.volley.Request.Method;
 import com.android.volley.RequestQueue;
 import com.android.volley.toolbox.JsonObjectRequest;
 import com.android.volley.toolbox.Volley;
+import com.example.placesdemo.BuildConfig;
 import com.example.placesdemo.MainActivity;
 import com.example.placesdemo.R;
 import com.example.placesdemo.model.GeocodingResult;
@@ -209,7 +210,7 @@ public class ProgrammaticAutocompleteToolbarActivity extends AppCompatActivity {
      */
     private void geocodePlaceAndDisplay(AutocompletePrediction placePrediction) {
         // Construct the request URL
-        final String apiKey = getString(R.string.places_api_key);
+        final String apiKey = BuildConfig.PLACES_API_KEY;
         final String url = "https://maps.googleapis.com/maps/api/geocode/json?place_id=%s&key=%s";
         final String requestURL = String.format(url, placePrediction.getPlaceId(), apiKey);
 

--- a/demo-java/gradle.properties
+++ b/demo-java/gradle.properties
@@ -18,5 +18,3 @@ android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
 android.enableR8=false
-
-PLACES_API_KEY="YOUR_API_KEY"

--- a/demo-kotlin/app/build.gradle
+++ b/demo-kotlin/app/build.gradle
@@ -13,7 +13,18 @@ android {
         multiDexEnabled true
         versionCode 1
         versionName "1.0"
-        resValue "string", "places_api_key", (project.findProperty("PLACES_API_KEY") ?: "")
+
+        // Read the API key from ./secure.properties into R.string.maps_api_key
+        def secureProps = new Properties()
+        if (file("../../secure.properties").exists()) {
+            file("../../secure.properties")?.withInputStream { secureProps.load(it) }
+        }
+        buildConfigField("String", "PLACES_API_KEY", (secureProps.getProperty("PLACES_API_KEY") ?: ""))
+
+        // To add your Maps API key to this project:
+        // 1. Create a file ./secure.properties
+        // 2. Add this line, where YOUR_API_KEY is your API key:
+        //        PLACES_API_KEY=YOUR_API_KEY
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/demo-kotlin/app/build.gradle
+++ b/demo-kotlin/app/build.gradle
@@ -19,7 +19,7 @@ android {
         if (file("../../secure.properties").exists()) {
             file("../../secure.properties")?.withInputStream { secureProps.load(it) }
         }
-        buildConfigField("String", "PLACES_API_KEY", (secureProps.getProperty("PLACES_API_KEY") ?: ""))
+        buildConfigField("String", "PLACES_API_KEY", (secureProps.getProperty("PLACES_API_KEY") ?: "\"\""))
 
         // To add your Maps API key to this project:
         // 1. Create a file ./secure.properties

--- a/demo-kotlin/app/src/gms/java/com/example/placesdemo/MainActivity.kt
+++ b/demo-kotlin/app/src/gms/java/com/example/placesdemo/MainActivity.kt
@@ -34,7 +34,7 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        val apiKey = getString(R.string.places_api_key)
+        val apiKey = BuildConfig.PLACES_API_KEY
         if (apiKey.isEmpty()) {
             Toast.makeText(this, getString(R.string.error_api_key), Toast.LENGTH_LONG).show()
             return

--- a/demo-kotlin/app/src/gms/java/com/example/placesdemo/programmatic_autocomplete/ProgrammaticAutocompleteToolbarActivity.kt
+++ b/demo-kotlin/app/src/gms/java/com/example/placesdemo/programmatic_autocomplete/ProgrammaticAutocompleteToolbarActivity.kt
@@ -183,7 +183,7 @@ class ProgrammaticAutocompleteToolbarActivity : AppCompatActivity() {
      *
      * @see https://developers.google.com/places/android-sdk/autocomplete#get_place_predictions_programmatically
      */
-    private fun geocodePlaceAndDisplay(placePrediction: AutocompletePrediction): Unit {
+    private fun geocodePlaceAndDisplay(placePrediction: AutocompletePrediction) {
         // Construct the request URL
         val apiKey = BuildConfig.PLACES_API_KEY
         val requestURL =

--- a/demo-kotlin/app/src/gms/java/com/example/placesdemo/programmatic_autocomplete/ProgrammaticAutocompleteToolbarActivity.kt
+++ b/demo-kotlin/app/src/gms/java/com/example/placesdemo/programmatic_autocomplete/ProgrammaticAutocompleteToolbarActivity.kt
@@ -31,6 +31,7 @@ import com.android.volley.Request
 import com.android.volley.RequestQueue
 import com.android.volley.toolbox.JsonObjectRequest
 import com.android.volley.toolbox.Volley
+import com.example.placesdemo.BuildConfig
 import com.example.placesdemo.MainActivity
 import com.example.placesdemo.R
 import com.example.placesdemo.model.GeocodingResult
@@ -184,7 +185,7 @@ class ProgrammaticAutocompleteToolbarActivity : AppCompatActivity() {
      */
     private fun geocodePlaceAndDisplay(placePrediction: AutocompletePrediction): Unit {
         // Construct the request URL
-        val apiKey = getString(R.string.places_api_key)
+        val apiKey = BuildConfig.PLACES_API_KEY
         val requestURL =
             "https://maps.googleapis.com/maps/api/geocode/json?place_id=${placePrediction.placeId}&key=$apiKey"
 

--- a/demo-kotlin/app/src/v3/java/com/example/placesdemo/MainActivity.kt
+++ b/demo-kotlin/app/src/v3/java/com/example/placesdemo/MainActivity.kt
@@ -41,7 +41,7 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        val apiKey = getString(R.string.places_api_key)
+        val apiKey = BuildConfig.PLACES_API_KEY
         if (apiKey.isEmpty()) {
             Toast.makeText(this, getString(R.string.error_api_key), Toast.LENGTH_LONG).show()
             return

--- a/demo-kotlin/app/src/v3/java/com/example/placesdemo/programmatic_autocomplete/ProgrammaticAutocompleteToolbarActivity.kt
+++ b/demo-kotlin/app/src/v3/java/com/example/placesdemo/programmatic_autocomplete/ProgrammaticAutocompleteToolbarActivity.kt
@@ -38,6 +38,7 @@ import com.android.volley.Request
 import com.android.volley.RequestQueue
 import com.android.volley.toolbox.JsonObjectRequest
 import com.android.volley.toolbox.Volley
+import com.example.placesdemo.BuildConfig
 import com.example.placesdemo.MainActivity
 import com.example.placesdemo.R
 import com.example.placesdemo.model.GeocodingResult
@@ -189,9 +190,9 @@ class ProgrammaticAutocompleteToolbarActivity : AppCompatActivity() {
      *
      * @see https://developers.google.com/places/android-sdk/autocomplete#get_place_predictions_programmatically
      */
-    private fun geocodePlaceAndDisplay(placePrediction: AutocompletePrediction): Unit {
+    private fun geocodePlaceAndDisplay(placePrediction: AutocompletePrediction) {
         // Construct the request URL
-        val apiKey = getString(R.string.places_api_key)
+        val apiKey = BuildConfig.PLACES_API_KEY
         val requestURL =
             "https://maps.googleapis.com/maps/api/geocode/json?place_id=${placePrediction.placeId}&key=$apiKey"
 

--- a/secure.properties.template
+++ b/secure.properties.template
@@ -1,0 +1,3 @@
+# This is a template for the `secure.properties` file
+# To use this, replace "YOUR_API_KEY" with your GMP API key and rename this file to `secure.properties`
+PLACES_API_KEY="YOUR_API_KEY"


### PR DESCRIPTION
Demonstrates hiding the API key from Git and providing it to the Places SDK by the build time generated `BuildConfig` object. It is also recommended to apply API key restrictions to improve the security should your key be compromised. [See Securing an API key](https://cloud.google.com/docs/authentication/api-keys#securing_an_api_key).