### PR TITLE
feat: add proximity checking to autocomplete address form java sample

### DIFF
--- a/demo-java/app/build.gradle
+++ b/demo-java/app/build.gradle
@@ -58,10 +58,14 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation 'androidx.navigation:navigation-fragment:2.3.5'
     implementation 'androidx.navigation:navigation-ui:2.3.5'
+    implementation "androidx.activity:activity:1.2.3"
+    implementation "androidx.fragment:fragment:1.3.4"
 
     // GMS
     gmsImplementation 'com.google.android.libraries.places:places:2.4.0'
+    gmsImplementation 'com.android.volley:volley:1.2.0'
     gmsImplementation 'com.google.android.gms:play-services-maps:17.0.1'
+    gmsImplementation 'com.google.maps.android:android-maps-utils:2.2.3'
 
     // V3
     v3Implementation name:'places-maps-sdk-3.1.0-beta', ext:'aar'

--- a/demo-java/app/src/gms/java/com/example/placesdemo/AutocompleteAddressActivity.java
+++ b/demo-java/app/src/gms/java/com/example/placesdemo/AutocompleteAddressActivity.java
@@ -1,6 +1,7 @@
 package com.example.placesdemo;
 
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
@@ -13,14 +14,14 @@ import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.Toast;
 
+import androidx.activity.result.ActivityResult;
+import androidx.activity.result.ActivityResultCallback;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
-import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.ContextCompat;
 
 import com.example.placesdemo.model.AutocompleteEditText;
-import com.google.android.gms.common.api.Status;
 import com.google.android.gms.location.FusedLocationProviderClient;
 import com.google.android.gms.location.LocationServices;
 import com.google.android.gms.maps.CameraUpdateFactory;
@@ -38,15 +39,12 @@ import com.google.android.libraries.places.api.model.AddressComponents;
 import com.google.android.libraries.places.api.model.Place;
 import com.google.android.libraries.places.api.net.PlacesClient;
 import com.google.android.libraries.places.widget.Autocomplete;
-import com.google.android.libraries.places.widget.AutocompleteActivity;
 import com.google.android.libraries.places.widget.model.AutocompleteActivityMode;
 
 import java.util.Arrays;
 import java.util.List;
 
 import static android.Manifest.permission.ACCESS_FINE_LOCATION;
-import static android.util.Log.e;
-import static android.util.Log.i;
 import static com.google.maps.android.SphericalUtil.computeDistanceBetween;
 
 /**
@@ -65,13 +63,28 @@ public class AutocompleteAddressActivity extends AppCompatActivity implements On
     private EditText postalField;
     private EditText countryField;
     private LatLng coordinates;
-    private Boolean checkProximity = false;
+    private boolean checkProximity = false;
     private SupportMapFragment mapFragment;
     private GoogleMap map;
     private Marker marker;
     private PlacesClient placesClient;
     private View mapPanel;
     private LatLng deviceLocation;
+    private static final double acceptableProximity = 150;
+
+    private ActivityResultLauncher<Intent> startAutocomplete = registerForActivityResult(
+            new ActivityResultContracts.StartActivityForResult(),
+            (ActivityResultCallback<ActivityResult>) result -> {
+                if (result.getResultCode() == Activity.RESULT_OK) {
+                    Intent intent = result.getData();
+                    Place place = Autocomplete.getPlaceFromIntent(intent);
+                    Log.d(TAG, "Place: " + place.getAddressComponents());
+
+                    fillInAddress(place);
+                } else if (result.getResultCode() == Activity.RESULT_CANCELED) {
+                    // The user canceled the operation.
+                }
+            });
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -99,6 +112,13 @@ public class AutocompleteAddressActivity extends AppCompatActivity implements On
         // Attach an Autocomplete intent to the Address 1 EditText field
         address1Field.setOnClickListener(v -> startAutocompleteIntent());
 
+        // Update checkProximity when user checks the checkbox
+        CheckBox checkProximityBox = findViewById(R.id.checkbox_proximity);
+        checkProximityBox.setOnCheckedChangeListener((view, isChecked) -> {
+            // Set the boolean to match user preference for when the Submit button is clicked
+            checkProximity = isChecked;
+        });
+
         // Submit and optionally check proximity
         Button saveButton = findViewById(R.id.autocomplete_save_button);
         saveButton.setOnClickListener(v -> saveForm());
@@ -107,6 +127,8 @@ public class AutocompleteAddressActivity extends AppCompatActivity implements On
         Button resetButton = findViewById(R.id.autocomplete_reset_button);
         resetButton.setOnClickListener(v -> clearForm());
     }
+
+
 
     private void startAutocompleteIntent() {
         // Set the fields to specify which types of place data to
@@ -117,28 +139,7 @@ public class AutocompleteAddressActivity extends AppCompatActivity implements On
         // Start the autocomplete intent.
         Intent intent = new Autocomplete.IntentBuilder(AutocompleteActivityMode.OVERLAY, fields)
                 .build(this);
-        startActivityForResult(intent, AUTOCOMPLETE_REQUEST_CODE);
-    }
-
-    @Override
-    protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
-        if (requestCode == AUTOCOMPLETE_REQUEST_CODE) {
-            if (resultCode == RESULT_OK) {
-                Place place = Autocomplete.getPlaceFromIntent(data);
-                i(TAG, "Place: " + place.getAddressComponents());
-
-                fillInAddress(place);
-
-            } else if (resultCode == AutocompleteActivity.RESULT_ERROR) {
-                // TODO: Handle the error.
-                Status status = Autocomplete.getStatusFromIntent(data);
-                i(TAG, status.getStatusMessage());
-            } else if (resultCode == RESULT_CANCELED) {
-                // The user canceled the operation.
-            }
-            return;
-        }
-        super.onActivityResult(requestCode, resultCode, data);
+        startAutocomplete.launch(intent);
     }
 
     @Override
@@ -151,25 +152,13 @@ public class AutocompleteAddressActivity extends AppCompatActivity implements On
                     MapStyleOptions.loadRawResourceStyle(this, R.raw.style_json));
 
             if (!success) {
-                e(TAG, "Style parsing failed.");
+                Log.e(TAG, "Style parsing failed.");
             }
         } catch (Resources.NotFoundException e) {
-            e(TAG, "Can't find style. Error: ", e);
+            Log.e(TAG, "Can't find style. Error: ", e);
         }
         map.moveCamera(CameraUpdateFactory.newLatLngZoom(coordinates, 15f));
         marker = map.addMarker(new MarkerOptions().position(coordinates));
-    }
-
-    public void onCheckboxClicked(View view) {
-        // Is the view now checked?
-        boolean checked = ((CheckBox) view).isChecked();
-
-        // Check which checkbox was clicked
-        switch (view.getId()) {
-            case R.id.checkbox_proximity:
-                checkProximity = checked;
-                break;
-        }
     }
 
     private void fillInAddress(Place place) {
@@ -270,12 +259,13 @@ public class AutocompleteAddressActivity extends AppCompatActivity implements On
     }
 
     private void saveForm() {
+        Log.d(TAG,"checkProximity = " + String.valueOf(checkProximity));
         if (checkProximity) {
             checkLocationPermissions();
         } else {
             Toast.makeText(
                     this,
-                    "Address accepted without checking proximity",
+                    R.string.autocomplete_skipped_message,
                     Toast.LENGTH_SHORT)
                     .show();
         }
@@ -298,32 +288,33 @@ public class AutocompleteAddressActivity extends AppCompatActivity implements On
     // system permissions dialog. Save the return value, an instance of
     // ActivityResultLauncher, as an instance variable.
     private ActivityResultLauncher<String> requestPermissionLauncher =
-            registerForActivityResult(new ActivityResultContracts.RequestPermission(), this::onActivityResult);
+            registerForActivityResult(new ActivityResultContracts.RequestPermission(), isGranted -> {
+                if (isGranted) {
+                    Log.d(TAG, "fine location permission granted upon request");
+                    getAndCompareLocations();
+                } else {
+                    Log.d(TAG, "fine location permission denied");
+                    Toast.makeText(
+                            this,
+                            R.string.autocomplete_denied_message,
+                            Toast.LENGTH_SHORT)
+                            .show();
+                }
+            });
 
     private void checkLocationPermissions() {
-        Toast toast = Toast.makeText(getApplicationContext(), "checking proximity", Toast.LENGTH_SHORT);
-        toast.show();
+        Toast.makeText(
+                getApplicationContext(),
+                R.string.autocomplete_progress_message,
+                Toast.LENGTH_SHORT)
+                .show();
         if (ContextCompat.checkSelfPermission(this, ACCESS_FINE_LOCATION)
                 == PackageManager.PERMISSION_GRANTED) {
-            Log.d(TAG, "fine location permission granted");
+            Log.d(TAG, "fine location permission already granted");
             getAndCompareLocations();
         } else {
             requestPermissionLauncher.launch(
                     ACCESS_FINE_LOCATION);
-        }
-    }
-
-    private void onActivityResult(Boolean isGranted) {
-        if (isGranted) {
-            Log.d(TAG, "permission granted upon request");
-            getAndCompareLocations();
-        } else {
-            Log.d(TAG, "permission denied");
-            Toast.makeText(
-                    this,
-                    "User denied location permission. Cannot check proximity to entered address.",
-                    Toast.LENGTH_SHORT)
-                    .show();
         }
     }
 
@@ -333,6 +324,7 @@ public class AutocompleteAddressActivity extends AppCompatActivity implements On
         // the coordinates variable to the Lat/Lng of the manually entered address. May use
         // Geocoding API to convert the manually entered address to a Lat/Lng.
         LatLng enteredLocation = coordinates;
+        map.setMyLocationEnabled(true);
 
         FusedLocationProviderClient fusedLocationClient =
                 LocationServices.getFusedLocationProviderClient(this);
@@ -340,30 +332,31 @@ public class AutocompleteAddressActivity extends AppCompatActivity implements On
         fusedLocationClient.getLastLocation()
                 .addOnSuccessListener(this, location -> {
                     // Got last known location. In some rare situations this can be null.
-                    if (location != null) {
-                        map.setMyLocationEnabled(true);
-                        deviceLocation = new LatLng(location.getLatitude(), location.getLongitude());
-                        Log.d(TAG, deviceLocation.toString());
-                        Log.d(TAG, enteredLocation.toString());
+                    if (location == null) {
+                        return;
+                    }
 
-                        // Use the computeDistanceBetween function in the Maps SDK for Android Utility Library
-                        // to use spherical geometry to compute the distance between two Lat/Lng points.
-                        double distanceInMeters = computeDistanceBetween(deviceLocation, enteredLocation);
-                        if (distanceInMeters < 150) {
-                            Log.d(TAG, "location matched");
-                            Toast.makeText(
-                                    getApplicationContext(),
-                                    "Device is within 150 meters of the entered address.",
-                                    Toast.LENGTH_SHORT)
-                                    .show();
-                        } else {
-                            Log.d(TAG, "location not matched");
-                            Toast.makeText(
-                                    getApplicationContext(),
-                                    "Device is more than 150 meters from the entered address.",
-                                    Toast.LENGTH_SHORT)
-                                    .show();
-                        }
+                    deviceLocation = new LatLng(location.getLatitude(), location.getLongitude());
+                    Log.d(TAG, "device location = " + deviceLocation.toString());
+                    Log.d(TAG, "entered location = " + enteredLocation.toString());
+
+                    // Use the computeDistanceBetween function in the Maps SDK for Android Utility Library
+                    // to use spherical geometry to compute the distance between two Lat/Lng points.
+                    double distanceInMeters = computeDistanceBetween(deviceLocation, enteredLocation);
+                    if (distanceInMeters <= acceptableProximity) {
+                        Log.d(TAG, "location matched");
+                        Toast.makeText(
+                                getApplicationContext(),
+                                R.string.autocomplete_match_message,
+                                Toast.LENGTH_SHORT)
+                                .show();
+                    } else {
+                        Log.d(TAG, "location not matched");
+                        Toast.makeText(
+                                getApplicationContext(),
+                                R.string.autocomplete_nomatch_message,
+                                Toast.LENGTH_SHORT)
+                                .show();
                     }
                 });
     }

--- a/demo-java/app/src/main/AndroidManifest.xml
+++ b/demo-java/app/src/main/AndroidManifest.xml
@@ -18,7 +18,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.example.placesdemo">
 
-  <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />

--- a/demo-java/app/src/main/AndroidManifest.xml
+++ b/demo-java/app/src/main/AndroidManifest.xml
@@ -18,8 +18,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.example.placesdemo">
 
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 
   <application

--- a/demo-java/app/src/main/res/layout/autocomplete_address_activity.xml
+++ b/demo-java/app/src/main/res/layout/autocomplete_address_activity.xml
@@ -136,6 +136,14 @@
         android:imeOptions="actionNext"
         android:inputType="text"/>
 
+    <!-- Proximity check option provided for development testing convenience.
+     User would typically not control this option. -->
+    <CheckBox android:id="@+id/checkbox_proximity"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/autocomplete_proximity_check"
+        android:onClick="onCheckboxClicked"/>
+
     <!-- The map for visual confirmation of the selected address -->
     <!-- Stub to only load the map after Autocomplete prediction selection -->
     <ViewStub

--- a/demo-java/app/src/main/res/layout/autocomplete_address_activity.xml
+++ b/demo-java/app/src/main/res/layout/autocomplete_address_activity.xml
@@ -141,8 +141,7 @@
     <CheckBox android:id="@+id/checkbox_proximity"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/autocomplete_proximity_check"
-        android:onClick="onCheckboxClicked"/>
+        android:text="@string/autocomplete_proximity_check"/>
 
     <!-- The map for visual confirmation of the selected address -->
     <!-- Stub to only load the map after Autocomplete prediction selection -->

--- a/demo-java/app/src/main/res/values/strings.xml
+++ b/demo-java/app/src/main/res/values/strings.xml
@@ -141,6 +141,9 @@
   <!-- Label for the address form's country field. -->
   <string name="autocomplete_country_label" translatable="false">Country/Region</string>
 
+  <!-- Label for the address form's proximity check setting. -->
+  <string name="autocomplete_proximity_check" translatable="false">Check device proximity</string>
+
   <!-- Label for the address form's confirmation map. -->
   <string name="autocomplete_map_label" translatable="false">Map view of the selected address</string>
 

--- a/demo-java/app/src/main/res/values/strings.xml
+++ b/demo-java/app/src/main/res/values/strings.xml
@@ -153,6 +153,21 @@
   <!-- Text for the address form reset button. -->
   <string name="autocomplete_reset_button" translatable="false">Clear form</string>
 
+  <!-- Text for the toast message for permissions denied. -->
+  <string name="autocomplete_denied_message" translatable="false">User denied location permission. Cannot check proximity to entered address.</string>
+
+  <!-- Text for the toast message for proximity match in progress. -->
+  <string name="autocomplete_progress_message" translatable="false">Checking proximity</string>
+
+  <!-- Text for the toast message for a successful proximity match. -->
+  <string name="autocomplete_match_message" translatable="false">Device location matches entered address</string>
+
+  <!-- Text for the toast message for a failed proximity match. -->
+  <string name="autocomplete_nomatch_message" translatable="false">Device location does not match entered address</string>
+
+  <!-- Text for the toast message for a skilled proximity match. -->
+  <string name="autocomplete_skipped_message" translatable="false">Address accepted without checking proximity</string>
+
   <!-- FETCH PLACE AND PHOTO -->
 
   <!-- Hint for the place ID field. -->

--- a/demo-java/build.gradle
+++ b/demo-java/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.1'
@@ -13,7 +13,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         flatDir {
             dirs 'libs'
         }


### PR DESCRIPTION
Add a checkbox to the autocomplete address form sample (Java only currently) to enable proximity checking.
If checked, app will request foreground fine location permissions to fetch the device location and compare it to the address entered via autocomplete on the form, indicating if the two locations are within a specified distance from each other.
