### PR TITLE
feat: bump places to 2.7.0

### DIFF
--- a/demo-java/app/build.gradle
+++ b/demo-java/app/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     implementation "com.github.bumptech.glide:glide:4.13.2"
 
     // GMS
-    gmsImplementation 'com.google.android.libraries.places:places:2.6.0'
+    gmsImplementation 'com.google.android.libraries.places:places:2.7.0'
     gmsImplementation 'com.google.android.gms:play-services-maps:18.0.2'
     gmsImplementation 'com.google.maps.android:android-maps-utils:2.3.0'
 

--- a/demo-java/app/src/gms/java/com/example/placesdemo/AutocompleteTestActivity.java
+++ b/demo-java/app/src/gms/java/com/example/placesdemo/AutocompleteTestActivity.java
@@ -16,6 +16,20 @@
 
 package com.example.placesdemo;
 
+import android.content.Intent;
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.view.View;
+import android.widget.CheckBox;
+import android.widget.EditText;
+import android.widget.TextView;
+
+import androidx.annotation.IdRes;
+import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+
 import com.google.android.gms.common.api.Status;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
@@ -26,7 +40,6 @@ import com.google.android.libraries.places.api.model.LocationBias;
 import com.google.android.libraries.places.api.model.LocationRestriction;
 import com.google.android.libraries.places.api.model.Place;
 import com.google.android.libraries.places.api.model.RectangularBounds;
-import com.google.android.libraries.places.api.model.TypeFilter;
 import com.google.android.libraries.places.api.net.FindAutocompletePredictionsRequest;
 import com.google.android.libraries.places.api.net.FindAutocompletePredictionsResponse;
 import com.google.android.libraries.places.api.net.PlacesClient;
@@ -36,24 +49,9 @@ import com.google.android.libraries.places.widget.AutocompleteSupportFragment;
 import com.google.android.libraries.places.widget.listener.PlaceSelectionListener;
 import com.google.android.libraries.places.widget.model.AutocompleteActivityMode;
 
-import android.content.Intent;
-import android.os.Bundle;
-import android.text.TextUtils;
-import android.view.View;
-import android.widget.ArrayAdapter;
-import android.widget.CheckBox;
-import android.widget.Spinner;
-import android.widget.TextView;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import androidx.annotation.IdRes;
-import androidx.annotation.Nullable;
-import androidx.annotation.StringRes;
-import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.app.AppCompatActivity;
 
 /**
  * Activity for testing Autocomplete (activity and fragment widgets, and programmatic).
@@ -64,6 +62,7 @@ public class AutocompleteTestActivity extends AppCompatActivity {
   private PlacesClient placesClient;
   private TextView responseView;
   private FieldSelector fieldSelector;
+  private EditText typesFilterEditText;
 
   @Override
   protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -83,13 +82,10 @@ public class AutocompleteTestActivity extends AppCompatActivity {
 
     // Set up view objects
     responseView = findViewById(R.id.response);
-    Spinner typeFilterSpinner = findViewById(R.id.autocomplete_type_filter);
-    typeFilterSpinner.setAdapter(
-        new ArrayAdapter<>(
-            this, android.R.layout.simple_list_item_1, Arrays.asList(TypeFilter.values())));
-    CheckBox useTypeFilterCheckBox = findViewById(R.id.autocomplete_use_type_filter);
-    useTypeFilterCheckBox.setOnCheckedChangeListener(
-        (buttonView, isChecked) -> typeFilterSpinner.setEnabled(isChecked));
+    typesFilterEditText = findViewById(R.id.autocomplete_types_filter_edittext);
+    CheckBox useTypesFilterCheckBox = findViewById(R.id.autocomplete_use_types_filter_checkbox);
+    useTypesFilterCheckBox.setOnCheckedChangeListener(
+            (buttonView, isChecked) -> typesFilterEditText.setEnabled(isChecked));
     fieldSelector =
         new FieldSelector(
                 findViewById(R.id.use_custom_fields),
@@ -108,7 +104,6 @@ public class AutocompleteTestActivity extends AppCompatActivity {
 
     // UI initialization
     setLoading(false);
-    typeFilterSpinner.setEnabled(false);
   }
 
   @Override
@@ -133,7 +128,7 @@ public class AutocompleteTestActivity extends AppCompatActivity {
                                 .setCountries(getCountries())
                                 .setLocationBias(getLocationBias())
                                 .setLocationRestriction(getLocationRestriction())
-                                .setTypeFilter(getTypeFilter())
+                                .setTypesFilter(getTypesFilter())
                                 .setActivityMode(getMode()));
   }
 
@@ -184,7 +179,6 @@ public class AutocompleteTestActivity extends AppCompatActivity {
                     .setCountries(getCountries())
                     .setLocationBias(getLocationBias())
                     .setLocationRestriction(getLocationRestriction())
-                    .setTypeFilter(getTypeFilter())
                     .build(this);
     startActivityForResult(autocompleteIntent, AUTOCOMPLETE_REQUEST_CODE);
   }
@@ -199,7 +193,7 @@ public class AutocompleteTestActivity extends AppCompatActivity {
                 .setOrigin((getOrigin()))
                 .setLocationBias(getLocationBias())
                 .setLocationRestriction(getLocationRestriction())
-                .setTypeFilter(getTypeFilter());
+                .setTypesFilter(getTypesFilter());
 
     if (isUseSessionTokenChecked()) {
       requestBuilder.setSessionToken(AutocompleteSessionToken.newInstance());
@@ -305,11 +299,13 @@ public class AutocompleteTestActivity extends AppCompatActivity {
     return origin;
   }
 
-  @Nullable
-  private TypeFilter getTypeFilter() {
-    Spinner typeFilter = findViewById(R.id.autocomplete_type_filter);
-    return typeFilter.isEnabled() ? (TypeFilter) typeFilter.getSelectedItem() : null;
+  private List<String> getTypesFilter() {
+    EditText typesFilterEditText = findViewById(R.id.autocomplete_types_filter_edittext);
+    return typesFilterEditText.isEnabled()
+            ? Arrays.asList(typesFilterEditText.getText().toString().split("[\\s,]+"))
+            : new ArrayList<>();
   }
+
 
   private AutocompleteActivityMode getMode() {
     boolean isOverlayMode =

--- a/demo-java/app/src/gms/java/com/example/placesdemo/AutocompleteTestActivity.java
+++ b/demo-java/app/src/gms/java/com/example/placesdemo/AutocompleteTestActivity.java
@@ -179,6 +179,7 @@ public class AutocompleteTestActivity extends AppCompatActivity {
                     .setCountries(getCountries())
                     .setLocationBias(getLocationBias())
                     .setLocationRestriction(getLocationRestriction())
+                    .setTypesFilter(getTypesFilter())
                     .build(this);
     startActivityForResult(autocompleteIntent, AUTOCOMPLETE_REQUEST_CODE);
   }

--- a/demo-java/app/src/main/res/layout/autocomplete_test_activity.xml
+++ b/demo-java/app/src/main/res/layout/autocomplete_test_activity.xml
@@ -137,19 +137,24 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:orientation="vertical">
 
       <CheckBox
-          android:id="@+id/autocomplete_use_type_filter"
+          android:id="@+id/autocomplete_use_types_filter_checkbox"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:checked="false"
-          android:text="@string/autocomplete_use_type_filter"/>
+          android:text="@string/autocomplete_use_types_filter"/>
 
-      <Spinner
-          android:id="@+id/autocomplete_type_filter"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"/>
+      <EditText
+          android:id="@+id/autocomplete_types_filter_edittext"
+          android:autofillHints=""
+          android:enabled="false"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:hint="@string/autocomplete_types_filter_hint"
+          android:inputType="text"/>
+
     </LinearLayout>
 
     <!-- Autocomplete predictions only -->

--- a/demo-java/app/src/main/res/layout/autocomplete_test_activity.xml
+++ b/demo-java/app/src/main/res/layout/autocomplete_test_activity.xml
@@ -157,6 +157,24 @@
 
     </LinearLayout>
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+      <CheckBox
+          android:id="@+id/autocomplete_use_type_filter"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:checked="false"
+          android:text="@string/autocomplete_use_type_filter"/>
+
+      <Spinner
+          android:id="@+id/autocomplete_type_filter"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"/>
+    </LinearLayout>
+
     <!-- Autocomplete predictions only -->
     <CheckBox
         android:id="@+id/autocomplete_use_session_token"

--- a/demo-java/app/src/main/res/values/strings.xml
+++ b/demo-java/app/src/main/res/values/strings.xml
@@ -93,6 +93,17 @@
     </font>
   </string>
 
+  <!-- KEEP UNTIL v3 REMOVED -->
+
+  <!-- Text for enabling autocomplete prediction's and widget's type filter field. -->
+  <string name="autocomplete_use_type_filter" translatable="false">Use TypeFilter? (Deprecated)</string>
+
+    <!-- Hint Text for the autocomplete prediction's and widget's type filter field. -->
+  <string name="autocomplete_type_filter" translatable="false">Type Filter</string>
+
+  <!-- END KEEP UNTIL v3 REMOVED -->
+
+
   <!-- Text for enabling autocomplete prediction's use of session tokens. -->
   <string name="autocomplete_use_session_token" translatable="false">(Predictions-only) Use session token?</string>
 

--- a/demo-java/app/src/main/res/values/strings.xml
+++ b/demo-java/app/src/main/res/values/strings.xml
@@ -65,9 +65,6 @@
   <!-- Hint for the autocomplete prediction's and widget's countries field. -->
   <string name="autocomplete_country_hint" translatable="false">Countries (e.g CH, US, RO)</string>
 
-  <!-- Hint Text for the autocomplete prediction's and widget's type filter field. -->
-  <string name="autocomplete_type_filter" translatable="false">Type Filter</string>
-
   <!-- Label for the autocomplete prediction's and widget's location origin field. -->
   <string name="autocomplete_location_origin_label" translatable="false">Location Origin (format: -33.2, 128.2)</string>
 
@@ -86,9 +83,15 @@
   <!-- Hint for the autocomplete prediction's and widget's location northeast field. -->
   <string name="autocomplete_location_north_east_hint" translatable="false">North East (lat, lng)</string>
 
+  <!-- Text for enabling autocomplete prediction's and widget's types filter field. -->
+  <string name="autocomplete_use_types_filter" translatable="false">Use TypesFilter?</string>
 
-  <!-- Text for enabling autocomplete prediction's and widget's type filter field. -->
-  <string name="autocomplete_use_type_filter" translatable="false">Use TypeFilter?</string>
+  <!-- Hint for the autocomplete prediction's and widget's types filter field. -->
+  <string name="autocomplete_types_filter_hint" translatable="false">
+    <font size="16">
+      Comma separated list of up to 5 place types
+    </font>
+  </string>
 
   <!-- Text for enabling autocomplete prediction's use of session tokens. -->
   <string name="autocomplete_use_session_token" translatable="false">(Predictions-only) Use session token?</string>

--- a/demo-kotlin/app/build.gradle
+++ b/demo-kotlin/app/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation "com.github.bumptech.glide:glide:4.13.2"
 
     // GMS
-    gmsImplementation 'com.google.android.libraries.places:places:2.6.0'
+    gmsImplementation 'com.google.android.libraries.places:places:2.7.0'
 
     // V3
     v3Implementation name:'places-maps-sdk-3.1.0-beta', ext:'aar'

--- a/demo-kotlin/app/src/gms/java/com/example/placesdemo/AutocompleteTestActivity.kt
+++ b/demo-kotlin/app/src/gms/java/com/example/placesdemo/AutocompleteTestActivity.kt
@@ -19,10 +19,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.text.TextUtils
 import android.view.View
-import android.widget.ArrayAdapter
-import android.widget.CheckBox
-import android.widget.Spinner
-import android.widget.TextView
+import android.widget.*
 import androidx.annotation.IdRes
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
@@ -36,7 +33,6 @@ import com.google.android.libraries.places.api.model.LocationBias
 import com.google.android.libraries.places.api.model.LocationRestriction
 import com.google.android.libraries.places.api.model.Place
 import com.google.android.libraries.places.api.model.RectangularBounds
-import com.google.android.libraries.places.api.model.TypeFilter
 import com.google.android.libraries.places.api.net.FindAutocompletePredictionsRequest
 import com.google.android.libraries.places.api.net.FindAutocompletePredictionsResponse
 import com.google.android.libraries.places.api.net.PlacesClient
@@ -55,6 +51,7 @@ class AutocompleteTestActivity : AppCompatActivity() {
     private lateinit var placesClient: PlacesClient
     private lateinit var responseView: TextView
     private lateinit var fieldSelector: FieldSelector
+    private lateinit var typesFilterEditText: EditText
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -72,11 +69,9 @@ class AutocompleteTestActivity : AppCompatActivity() {
 
         // Set up view objects
         responseView = findViewById(R.id.response)
-        val typeFilterSpinner = findViewById<Spinner>(R.id.autocomplete_type_filter)
-        typeFilterSpinner.adapter = ArrayAdapter(
-            this, android.R.layout.simple_list_item_1, Arrays.asList(*TypeFilter.values()))
-        val useTypeFilterCheckBox = findViewById<CheckBox>(R.id.autocomplete_use_type_filter)
-        useTypeFilterCheckBox.setOnCheckedChangeListener { _, isChecked: Boolean -> typeFilterSpinner.isEnabled = isChecked }
+        typesFilterEditText = findViewById(R.id.autocomplete_types_filter_edittext)
+        val useTypesFilterCheckBox = findViewById<CheckBox>(R.id.autocomplete_use_types_filter_checkbox)
+        useTypesFilterCheckBox.setOnCheckedChangeListener { buttonView, isChecked: Boolean -> typesFilterEditText.isEnabled = isChecked }
         fieldSelector = FieldSelector(
             findViewById(R.id.use_custom_fields),
             findViewById(R.id.custom_fields_list),
@@ -93,7 +88,6 @@ class AutocompleteTestActivity : AppCompatActivity() {
 
         // UI initialization
         setLoading(false)
-        typeFilterSpinner.isEnabled = false
     }
 
     override fun onSaveInstanceState(bundle: Bundle) {
@@ -114,7 +108,7 @@ class AutocompleteTestActivity : AppCompatActivity() {
                     .setCountries(countries)
                     .setLocationBias(locationBias)
                     .setLocationRestriction(locationRestriction)
-                    .setTypeFilter(typeFilter)
+                    .setTypesFilter(getTypesFilter())
                     .setActivityMode(mode)
             }
     }
@@ -163,7 +157,7 @@ class AutocompleteTestActivity : AppCompatActivity() {
             .setCountries(countries)
             .setLocationBias(locationBias)
             .setLocationRestriction(locationRestriction)
-            .setTypeFilter(typeFilter)
+            .setTypesFilter(getTypesFilter())
             .build(this)
         startActivityForResult(autocompleteIntent, AUTOCOMPLETE_REQUEST_CODE)
     }
@@ -176,7 +170,7 @@ class AutocompleteTestActivity : AppCompatActivity() {
             .setOrigin(origin)
             .setLocationBias(locationBias)
             .setLocationRestriction(locationRestriction)
-            .setTypeFilter(typeFilter)
+            .setTypesFilter(getTypesFilter())
         if (isUseSessionTokenChecked) {
             requestBuilder.setSessionToken(AutocompleteSessionToken.newInstance())
         }
@@ -257,11 +251,12 @@ class AutocompleteTestActivity : AppCompatActivity() {
             return origin
         }
 
-    private val typeFilter: TypeFilter?
-        get() {
-            val typeFilter = findViewById<Spinner>(R.id.autocomplete_type_filter)
-            return if (typeFilter.isEnabled) typeFilter.selectedItem as TypeFilter else null
-        }
+    private fun getTypesFilter(): List<String> {
+        typesFilterEditText = findViewById(R.id.autocomplete_types_filter_edittext)
+        return if (typesFilterEditText.isEnabled)
+            typesFilterEditText.text.toString().split("[\\s,]+".toRegex()) as List<String>
+        else emptyList<String>()
+    }
 
     private val mode: AutocompleteActivityMode
         get() {

--- a/demo-kotlin/app/src/main/res/layout/autocomplete_test_activity.xml
+++ b/demo-kotlin/app/src/main/res/layout/autocomplete_test_activity.xml
@@ -137,19 +137,24 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:orientation="vertical">
 
       <CheckBox
-          android:id="@+id/autocomplete_use_type_filter"
+          android:id="@+id/autocomplete_use_types_filter_checkbox"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:checked="false"
-          android:text="@string/autocomplete_use_type_filter"/>
+          android:text="@string/autocomplete_use_types_filter"/>
 
-      <Spinner
-          android:id="@+id/autocomplete_type_filter"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"/>
+      <EditText
+          android:id="@+id/autocomplete_types_filter_edittext"
+          android:autofillHints=""
+          android:enabled="false"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:hint="@string/autocomplete_types_filter_hint"
+          android:inputType="text"/>
+
     </LinearLayout>
 
     <!-- Autocomplete predictions only -->

--- a/demo-kotlin/app/src/main/res/layout/autocomplete_test_activity.xml
+++ b/demo-kotlin/app/src/main/res/layout/autocomplete_test_activity.xml
@@ -157,6 +157,24 @@
 
     </LinearLayout>
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+      <CheckBox
+          android:id="@+id/autocomplete_use_type_filter"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:checked="false"
+          android:text="@string/autocomplete_use_type_filter"/>
+
+      <Spinner
+          android:id="@+id/autocomplete_type_filter"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"/>
+    </LinearLayout>
+
     <!-- Autocomplete predictions only -->
     <CheckBox
         android:id="@+id/autocomplete_use_session_token"

--- a/demo-kotlin/app/src/main/res/values/strings.xml
+++ b/demo-kotlin/app/src/main/res/values/strings.xml
@@ -59,8 +59,15 @@
   <!-- Hint for the autocomplete prediction's and widget's countries field. -->
   <string name="autocomplete_country_hint" translatable="false">Countries (e.g CH, US, RO)</string>
 
-  <!-- Hint Text for the autocomplete prediction's and widget's type filter field. -->
-  <string name="autocomplete_type_filter" translatable="false">Type Filter</string>
+  <!-- Text for enabling autocomplete prediction's and widget's types filter field. -->
+  <string name="autocomplete_use_types_filter" translatable="false">Use TypesFilter?</string>
+
+  <!-- Hint for the autocomplete prediction's and widget's types filter field. -->
+  <string name="autocomplete_types_filter_hint" translatable="false">
+    <font size="16">
+      Comma separated list of up to 5 place types
+    </font>
+  </string>
 
   <!-- Label for the autocomplete prediction's and widget's location origin field. -->
   <string name="autocomplete_location_origin_label" translatable="false">Location Origin (format: -33.2, 128.2)</string>
@@ -79,10 +86,6 @@
 
   <!-- Hint for the autocomplete prediction's and widget's location northeast field. -->
   <string name="autocomplete_location_north_east_hint" translatable="false">North East (lat, lng)</string>
-
-
-  <!-- Text for enabling autocomplete prediction's and widget's type filter field. -->
-  <string name="autocomplete_use_type_filter" translatable="false">Use TypeFilter?</string>
 
   <!-- Text for enabling autocomplete prediction's use of session tokens. -->
   <string name="autocomplete_use_session_token" translatable="false">(Predictions-only) Use session token?</string>

--- a/demo-kotlin/app/src/main/res/values/strings.xml
+++ b/demo-kotlin/app/src/main/res/values/strings.xml
@@ -69,6 +69,17 @@
     </font>
   </string>
 
+
+  <!-- KEEP UNTIL v3 REMOVED -->
+
+  <!-- Text for enabling autocomplete prediction's and widget's type filter field. -->
+  <string name="autocomplete_use_type_filter" translatable="false">Use TypeFilter? (Deprecated)</string>
+
+  <!-- Hint Text for the autocomplete prediction's and widget's type filter field. -->
+  <string name="autocomplete_type_filter" translatable="false">Type Filter</string>
+
+  <!-- END KEEP UNTIL v3 REMOVED -->
+
   <!-- Label for the autocomplete prediction's and widget's location origin field. -->
   <string name="autocomplete_location_origin_label" translatable="false">Location Origin (format: -33.2, 128.2)</string>
 

--- a/demo-kotlin/gradle.properties
+++ b/demo-kotlin/gradle.properties
@@ -17,5 +17,3 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
-
-PLACES_API_KEY="YOUR_API_KEY"

--- a/snippets/app/build.gradle
+++ b/snippets/app/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     // [END_EXCLUDE]
     // [START maps_android_places_upgrade_snippet]
-    implementation 'com.google.android.libraries.places:places:2.6.0'
+    implementation 'com.google.android.libraries.places:places:2.7.0'
     // [END maps_android_places_upgrade_snippet]
 }
 // [END maps_android_places_install_snippet]

--- a/snippets/app/src/main/java/com/google/places/PlaceAutocompleteActivity.java
+++ b/snippets/app/src/main/java/com/google/places/PlaceAutocompleteActivity.java
@@ -178,7 +178,7 @@ class PlaceAutocompleteActivity extends AppCompatActivity {
             //.setLocationRestriction(bounds)
             .setOrigin(new LatLng(-33.8749937,151.2041382))
             .setCountries("AU", "NZ")
-            .setTypeFilter(TypeFilter.ADDRESS)
+            .setTypesFilter(Arrays.asList(TypeFilter.ADDRESS.toString()))
             .setSessionToken(token)
             .setQuery(query)
             .build();

--- a/snippets/app/src/main/java/com/google/places/PlaceAutocompleteActivity.java
+++ b/snippets/app/src/main/java/com/google/places/PlaceAutocompleteActivity.java
@@ -103,14 +103,18 @@ class PlaceAutocompleteActivity extends AppCompatActivity {
         // [END maps_places_autocomplete_location_restriction]
 
         // [START maps_places_autocomplete_type_filter]
-        autocompleteFragment.setTypeFilter(TypeFilter.ADDRESS);
+        autocompleteFragment.setTypesFilter(Arrays.asList(TypeFilter.ADDRESS.toString()));
         // [END maps_places_autocomplete_type_filter]
+
+        // [START maps_places_autocomplete_type_filter_multiple]
+        autocompleteFragment.setTypesFilter(Arrays.asList("landmark", "restaurant", "store"));
+        // [END maps_places_autocomplete_type_filter_multiple]
 
         List<Place.Field> fields = new ArrayList<>();
         // [START maps_places_intent_type_filter]
         Intent intent = new Autocomplete.IntentBuilder(
             AutocompleteActivityMode.FULLSCREEN, fields)
-            .setTypeFilter(TypeFilter.ADDRESS)
+            .setTypesFilter(Arrays.asList(TypeFilter.ADDRESS.toString()))
             .build(this);
         startActivityForResult(intent, AUTOCOMPLETE_REQUEST_CODE);
         // [END maps_places_intent_type_filter]

--- a/snippets/app/src/main/java/com/google/places/kotlin/PlaceAutocompleteActivity.kt
+++ b/snippets/app/src/main/java/com/google/places/kotlin/PlaceAutocompleteActivity.kt
@@ -108,7 +108,7 @@ class PlaceAutocompleteActivity : AppCompatActivity() {
         val fields: List<Place.Field> = ArrayList()
         // [START maps_places_intent_type_filter]
         val intent = Autocomplete.IntentBuilder(AutocompleteActivityMode.FULLSCREEN, fields)
-            .setTypeFilter(TypeFilter.ADDRESS)
+            .setTypesFilter(listOf(TypeFilter.ADDRESS.toString()))
             .build(this)
         startActivityForResult(intent, AUTOCOMPLETE_REQUEST_CODE)
         // [END maps_places_intent_type_filter]
@@ -181,7 +181,7 @@ class PlaceAutocompleteActivity : AppCompatActivity() {
                 //.setLocationRestriction(bounds)
                 .setOrigin(LatLng(-33.8749937, 151.2041382))
                 .setCountries("AU", "NZ")
-                .setTypeFilter(TypeFilter.ADDRESS)
+                .setTypesFilter(listOf(TypeFilter.ADDRESS.toString()))
                 .setSessionToken(token)
                 .setQuery(query)
                 .build()

--- a/snippets/app/src/main/java/com/google/places/kotlin/PlaceAutocompleteActivity.kt
+++ b/snippets/app/src/main/java/com/google/places/kotlin/PlaceAutocompleteActivity.kt
@@ -98,8 +98,12 @@ class PlaceAutocompleteActivity : AppCompatActivity() {
         // [END maps_places_autocomplete_location_restriction]
 
         // [START maps_places_autocomplete_type_filter]
-        autocompleteFragment.setTypeFilter(TypeFilter.ADDRESS)
+        autocompleteFragment.setTypesFilter(listOf(TypeFilter.ADDRESS.toString()))
         // [END maps_places_autocomplete_type_filter]
+
+        // [START maps_places_autocomplete_type_filter_multiple]
+        autocompleteFragment.setTypesFilter(listOf("landmark", "restaurant", "store"))
+        // [END maps_places_autocomplete_type_filter_multiple]
 
         val fields: List<Place.Field> = ArrayList()
         // [START maps_places_intent_type_filter]


### PR DESCRIPTION
Update samples and snippets for Places SDK for Android 2.7.0.

Add Place Autocomplete examples of setTypesFilter() to replace deprecated setTypeFilter().
