### PR TITLE
chore(dependencies): general update of dependencies

### DIFF
--- a/demo-java/app/build.gradle
+++ b/demo-java/app/build.gradle
@@ -6,11 +6,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     defaultConfig {
         applicationId "com.example.placesdemo"
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 33
         multiDexEnabled true
         versionCode 1
         versionName "1.0"
@@ -38,6 +38,7 @@ android {
             versionNameSuffix "-v3"
         }
     }
+    namespace 'com.example.placesdemo'
 }
 
 task generateV3(type: Copy) {
@@ -53,28 +54,28 @@ task generateV3(type: Copy) {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation 'com.google.android.material:material:1.6.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
-    implementation 'androidx.navigation:navigation-fragment:2.4.2'
-    implementation 'androidx.navigation:navigation-ui:2.4.2'
-    implementation "androidx.activity:activity:1.4.0"
-    implementation "androidx.fragment:fragment:1.4.1"
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'com.google.android.material:material:1.7.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.navigation:navigation-fragment:2.5.3'
+    implementation 'androidx.navigation:navigation-ui:2.5.3'
+    implementation "androidx.activity:activity:1.6.1"
+    implementation "androidx.fragment:fragment:1.5.4"
     implementation 'com.android.volley:volley:1.2.1'
     implementation "com.github.bumptech.glide:glide:4.13.2"
 
     // GMS
     gmsImplementation 'com.google.android.libraries.places:places:2.7.0'
-    gmsImplementation 'com.google.android.gms:play-services-maps:18.0.2'
-    gmsImplementation 'com.google.maps.android:android-maps-utils:2.3.0'
+    gmsImplementation 'com.google.android.gms:play-services-maps:18.1.0'
+    gmsImplementation 'com.google.maps.android:android-maps-utils:2.4.0'
 
     // V3
     v3Implementation name:'places-maps-sdk-3.1.0-beta', ext:'aar'
-    v3Implementation 'com.google.android.gms:play-services-base:18.0.1'
-    v3Implementation 'com.google.android.gms:play-services-basement:18.0.2'
+    v3Implementation 'com.google.android.gms:play-services-base:18.1.0'
+    v3Implementation 'com.google.android.gms:play-services-basement:18.1.0'
     v3Implementation 'com.google.android.gms:play-services-gcm:17.0.0'
-    v3Implementation 'com.google.android.gms:play-services-location:19.0.1'
-    v3Implementation 'com.google.android.gms:play-services-tasks:18.0.1'
+    v3Implementation 'com.google.android.gms:play-services-location:21.0.1'
+    v3Implementation 'com.google.android.gms:play-services-tasks:18.0.2'
     v3Implementation 'com.google.android.libraries.maps:maps:3.1.0-beta'
     v3Implementation 'com.google.auto.value:auto-value-annotations:1.9'
     v3Implementation 'com.google.code.gson:gson:2.9.0'

--- a/demo-java/app/src/main/AndroidManifest.xml
+++ b/demo-java/app/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
  limitations under the License.
 -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.example.placesdemo">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/demo-java/build.gradle
+++ b/demo-java/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.1"
     }
 }

--- a/demo-java/gradle/wrapper/gradle-wrapper.properties
+++ b/demo-java/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Mar 28 15:43:44 PDT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/demo-kotlin/app/build.gradle
+++ b/demo-kotlin/app/build.gradle
@@ -8,11 +8,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     defaultConfig {
         applicationId "com.example.placesdemo"
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 33
         multiDexEnabled true
         versionCode 1
         versionName "1.0"
@@ -34,6 +34,7 @@ android {
             versionNameSuffix "-v3"
         }
     }
+    namespace 'com.example.placesdemo'
 }
 
 // Deprecated
@@ -51,10 +52,10 @@ task generateV3(type: Copy) {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation 'androidx.core:core-ktx:1.7.0'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'androidx.core:core-ktx:1.9.0'
     implementation 'com.android.support:multidex:1.0.3'
-    implementation 'com.google.android.material:material:1.6.0'
+    implementation 'com.google.android.material:material:1.7.0'
     implementation 'com.android.volley:volley:1.2.1'
     implementation "com.github.bumptech.glide:glide:4.13.2"
 
@@ -63,11 +64,11 @@ dependencies {
 
     // V3
     v3Implementation name:'places-maps-sdk-3.1.0-beta', ext:'aar'
-    v3Implementation 'com.google.android.gms:play-services-base:18.0.1'
-    v3Implementation 'com.google.android.gms:play-services-basement:18.0.2'
+    v3Implementation 'com.google.android.gms:play-services-base:18.1.0'
+    v3Implementation 'com.google.android.gms:play-services-basement:18.1.0'
     v3Implementation 'com.google.android.gms:play-services-gcm:17.0.0'
-    v3Implementation 'com.google.android.gms:play-services-location:19.0.1'
-    v3Implementation 'com.google.android.gms:play-services-tasks:18.0.1'
+    v3Implementation 'com.google.android.gms:play-services-location:21.0.1'
+    v3Implementation 'com.google.android.gms:play-services-tasks:18.0.2'
     v3Implementation 'com.google.android.libraries.maps:maps:3.1.0-beta'
     v3Implementation 'com.google.auto.value:auto-value-annotations:1.9'
     v3Implementation 'com.google.code.gson:gson:2.9.0'

--- a/demo-kotlin/app/src/gms/java/com/example/placesdemo/AutocompleteTestActivity.kt
+++ b/demo-kotlin/app/src/gms/java/com/example/placesdemo/AutocompleteTestActivity.kt
@@ -127,6 +127,7 @@ class AutocompleteTestActivity : AppCompatActivity() {
     /**
      * Called when AutocompleteActivity finishes
      */
+    @Deprecated("Deprecated in Java")
     override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
         if (requestCode == AUTOCOMPLETE_REQUEST_CODE && intent != null) {
             when (resultCode) {

--- a/demo-kotlin/app/src/main/AndroidManifest.xml
+++ b/demo-kotlin/app/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
  limitations under the License.
 -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.example.placesdemo">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/demo-kotlin/build.gradle
+++ b/demo-kotlin/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.7.21'
 
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.1"
     }

--- a/demo-kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/demo-kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Mar 28 15:44:27 PDT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/snippets/app/build.gradle
+++ b/snippets/app/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdk 31
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.google.places"
         minSdk 21
-        targetSdk 31
+        targetSdk 33
         versionCode 1
         versionName "1.0"
 
@@ -25,6 +25,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    namespace 'com.google.places'
 }
 
 // [START maps_android_places_install_snippet]
@@ -32,14 +33,14 @@ dependencies {
     // [START_EXCLUDE silent]
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'com.android.volley:volley:1.2.1'
     implementation "com.github.bumptech.glide:glide:4.13.2"
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
     // [END_EXCLUDE]
     // [START maps_android_places_upgrade_snippet]
     implementation 'com.google.android.libraries.places:places:2.7.0'

--- a/snippets/app/src/main/AndroidManifest.xml
+++ b/snippets/app/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
  limitations under the License.
 -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.places">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 

--- a/snippets/build.gradle
+++ b/snippets/build.gradle
@@ -1,12 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.7.10"
+    ext.kotlin_version = "1.7.21"
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.1.3"
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/snippets/gradle/wrapper/gradle-wrapper.properties
+++ b/snippets/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip


### PR DESCRIPTION
The current Pull Request introduces a general update of dependencies, and supersedes all the existing dependabot PRs.

This PR affecs the `demo-java`, `demo-kotlin` and `snippets` projects.

- Increased `compileSdkVersion`.
- Increased `targetSdkVersion`.
- Moves namespace from AndroidManifest to the `build.gradle` file.
- Increases Gradle plugin version.
- General dependencies updated.

This supersedes all the existing dependabot PRs:

#447, #446,#445,#444,#443,#441,#440,#439,#438,#437,#436,#435,#433,#431,#430,#429,#420,#419,#418,#416,#415,#401,#397,#396,#395,#394,#379 and #378.

