### PR TITLE
feat: add samples for release 3.1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,12 +33,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: set up JDK 11
-      uses: actions/setup-java@v2.3.1
+    - name: set up JDK 17
+      uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'adopt'
 
     - name: Install NDK
@@ -59,12 +59,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: set up JDK 11
-      uses: actions/setup-java@v2.3.1
+    - name: set up JDK 17
+      uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'adopt'
 
     - name: Install NDK
@@ -85,12 +85,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: set up JDK 11
-      uses: actions/setup-java@v2.3.1
+    - name: set up JDK 17
+      uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'adopt'
 
     - name: Install NDK
@@ -106,12 +106,12 @@ jobs:
       with:
         name: snippets-build-reports
         path: snippets/app/build/reports
-  
+
   test: # used as required status check
     runs-on: ubuntu-latest
     needs:
       - build-demo-java
       - build-demo-kotlin
-      - build-snippets      
-    steps: 
+      - build-snippets
+    steps:
       - run: echo "Fail if all other steps are not successful"

--- a/demo-java/app/build.gradle
+++ b/demo-java/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
+    id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
 }
 
 android {
@@ -32,7 +33,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.navigation:navigation-fragment:2.5.3'
     implementation 'androidx.navigation:navigation-ui:2.5.3'
-    implementation "androidx.activity:activity:1.7.1"
+    implementation "androidx.activity:activity:1.6.1"
     implementation "androidx.fragment:fragment:1.5.7"
     implementation 'com.android.volley:volley:1.2.1'
     implementation "com.github.bumptech.glide:glide:4.13.2"

--- a/demo-java/app/build.gradle
+++ b/demo-java/app/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation "com.android.databinding:viewbinding:7.3.1"
 
     // Places and Maps SDKs
-    implementation 'com.google.android.libraries.places:places:3.0.0'
+    implementation 'com.google.android.libraries.places:places:3.1.0'
     implementation 'com.google.android.gms:play-services-maps:18.1.0'
     implementation 'com.google.maps.android:android-maps-utils:2.4.0'
 }

--- a/demo-java/app/build.gradle
+++ b/demo-java/app/build.gradle
@@ -50,7 +50,7 @@ dependencies {
 
 secrets {
     // To add your Google Maps Platform API key to this project:
-    // 1. Create or open file local.properties in this folder, which will be ready by default
+    // 1. Create or open file local.properties in this folder, which will be read by default
     //    by secrets_gradle_plugin
     // 2. Add this line, replacing YOUR_API_KEY with a key from a project with Places API enabled:
     //        PLACES_API_KEY=YOUR_API_KEY

--- a/demo-java/app/build.gradle
+++ b/demo-java/app/build.gradle
@@ -19,10 +19,6 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
     namespace 'com.example.placesdemo'
 
     buildFeatures {
@@ -31,16 +27,16 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'com.google.android.material:material:1.7.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.8.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.navigation:navigation-fragment:2.5.3'
     implementation 'androidx.navigation:navigation-ui:2.5.3'
-    implementation "androidx.activity:activity:1.6.1"
-    implementation "androidx.fragment:fragment:1.5.5"
+    implementation "androidx.activity:activity:1.7.1"
+    implementation "androidx.fragment:fragment:1.5.7"
     implementation 'com.android.volley:volley:1.2.1'
     implementation "com.github.bumptech.glide:glide:4.13.2"
-    implementation "com.android.databinding:viewbinding:7.3.1"
+    implementation "com.android.databinding:viewbinding:8.0.0"
 
     // Places and Maps SDKs
     implementation 'com.google.android.libraries.places:places:3.1.0'

--- a/demo-java/app/src/main/AndroidManifest.xml
+++ b/demo-java/app/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+  <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
   <application
     android:allowBackup="true"

--- a/demo-java/app/src/main/AndroidManifest.xml
+++ b/demo-java/app/src/main/AndroidManifest.xml
@@ -49,8 +49,8 @@
         android:name=".AutocompleteAddressActivity"
         android:windowSoftInputMode="stateHidden" />
     <activity android:name=".PlaceDetailsAndPhotosActivity" />
-    <activity android:name=".CurrentPlaceActivity" />
     <activity android:name=".PlaceIsOpenActivity"/>
+    <activity android:name=".CurrentPlaceActivity" />
     <activity
       android:name=".programmatic_autocomplete.ProgrammaticAutocompleteToolbarActivity"
       android:theme="@style/Theme.AppCompat.Light.NoActionBar" />

--- a/demo-java/app/src/main/AndroidManifest.xml
+++ b/demo-java/app/src/main/AndroidManifest.xml
@@ -50,6 +50,7 @@
         android:windowSoftInputMode="stateHidden" />
     <activity android:name=".PlaceDetailsAndPhotosActivity" />
     <activity android:name=".CurrentPlaceActivity" />
+    <activity android:name=".PlaceIsOpenActivity"/>
     <activity
       android:name=".programmatic_autocomplete.ProgrammaticAutocompleteToolbarActivity"
       android:theme="@style/Theme.AppCompat.Light.NoActionBar" />

--- a/demo-java/app/src/main/java/com/example/placesdemo/AutocompleteAddressActivity.java
+++ b/demo-java/app/src/main/java/com/example/placesdemo/AutocompleteAddressActivity.java
@@ -155,7 +155,7 @@ public class AutocompleteAddressActivity extends AppCompatActivity implements On
 
         // Build the autocomplete intent with field, country, and type filters applied
         Intent intent = new Autocomplete.IntentBuilder(AutocompleteActivityMode.OVERLAY, fields)
-                .setCountry("US")
+                .setCountries(Arrays.asList("US"))
                 .setTypesFilter(new ArrayList<String>() {{
                     add(TypeFilter.ADDRESS.toString().toLowerCase());
                 }})

--- a/demo-java/app/src/main/java/com/example/placesdemo/CurrentPlaceActivity.java
+++ b/demo-java/app/src/main/java/com/example/placesdemo/CurrentPlaceActivity.java
@@ -100,13 +100,25 @@ public class CurrentPlaceActivity extends AppCompatActivity {
         List<Field> placeFields = FieldSelector.allExcept(
                 Field.ADDRESS_COMPONENTS,
                 Field.CURBSIDE_PICKUP,
+                Field.CURRENT_OPENING_HOURS,
                 Field.DELIVERY,
                 Field.DINE_IN,
                 Field.OPENING_HOURS,
                 Field.PHONE_NUMBER,
+                Field.RESERVABLE,
+                Field.SECONDARY_OPENING_HOURS,
+                Field.SERVES_BEER,
+                Field.SERVES_BREAKFAST,
+                Field.SERVES_BRUNCH,
+                Field.SERVES_DINNER,
+                Field.SERVES_LUNCH,
+                Field.SERVES_VEGETARIAN_FOOD,
+                Field.SERVES_WINE,
                 Field.UTC_OFFSET,
                 Field.TAKEOUT,
-                Field.WEBSITE_URI);
+                Field.WEBSITE_URI,
+                Field.WHEELCHAIR_ACCESSIBLE_ENTRANCE
+        );
         fieldSelector = new FieldSelector(
                 binding.useCustomFields,
                 binding.customFieldsList,

--- a/demo-java/app/src/main/java/com/example/placesdemo/MainActivity.java
+++ b/demo-java/app/src/main/java/com/example/placesdemo/MainActivity.java
@@ -16,15 +16,15 @@
 
 package com.example.placesdemo;
 
-import com.example.placesdemo.programmatic_autocomplete.ProgrammaticAutocompleteToolbarActivity;
-import com.google.android.libraries.places.api.Places;
-
 import android.content.Intent;
 import android.os.Bundle;
 import android.widget.Toast;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+
+import com.example.placesdemo.programmatic_autocomplete.ProgrammaticAutocompleteToolbarActivity;
+import com.google.android.libraries.places.api.Places;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -47,7 +47,8 @@ public class MainActivity extends AppCompatActivity {
 
         setLaunchActivityClickListener(R.id.autocomplete_button, PlaceAutocompleteActivity.class);
         setLaunchActivityClickListener(R.id.autocomplete_address_button, AutocompleteAddressActivity.class);
-        setLaunchActivityClickListener(R.id.programmatic_autocomplete_button, ProgrammaticAutocompleteToolbarActivity.class);
+        setLaunchActivityClickListener(R.id.programmatic_autocomplete_button, ProgrammaticAutocompleteToolbarActivity.class
+        );
         setLaunchActivityClickListener(R.id.place_and_photo_button, PlaceDetailsAndPhotosActivity.class);
         setLaunchActivityClickListener(R.id.is_open_button, PlaceIsOpenActivity.class);
         setLaunchActivityClickListener(R.id.current_place_button, CurrentPlaceActivity.class);

--- a/demo-java/app/src/main/java/com/example/placesdemo/MainActivity.java
+++ b/demo-java/app/src/main/java/com/example/placesdemo/MainActivity.java
@@ -49,6 +49,7 @@ public class MainActivity extends AppCompatActivity {
         setLaunchActivityClickListener(R.id.autocomplete_address_button, AutocompleteAddressActivity.class);
         setLaunchActivityClickListener(R.id.programmatic_autocomplete_button, ProgrammaticAutocompleteToolbarActivity.class);
         setLaunchActivityClickListener(R.id.place_and_photo_button, PlaceDetailsAndPhotosActivity.class);
+        setLaunchActivityClickListener(R.id.is_open_button, PlaceIsOpenActivity.class);
         setLaunchActivityClickListener(R.id.current_place_button, CurrentPlaceActivity.class);
     }
 

--- a/demo-java/app/src/main/java/com/example/placesdemo/PlaceIsOpenActivity.java
+++ b/demo-java/app/src/main/java/com/example/placesdemo/PlaceIsOpenActivity.java
@@ -12,13 +12,13 @@ import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ArrayAdapter;
 import android.widget.CheckBox;
 import android.widget.EditText;
-import android.widget.Spinner;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.example.placesdemo.databinding.PlaceIsOpenActivityBinding;
 import com.google.android.gms.tasks.Task;
 import com.google.android.libraries.places.api.Places;
 import com.google.android.libraries.places.api.model.Place;
@@ -44,11 +44,8 @@ public class PlaceIsOpenActivity extends AppCompatActivity {
     private final String defaultTimeZone = "America/Los_Angeles";
     @NonNull
     private Calendar isOpenCalendar = Calendar.getInstance();
+    private PlaceIsOpenActivityBinding binding;
 
-    private EditText editTextIsOpenDate;
-    private EditText editTextIsOpenTime;
-    private TextView textViewResponse;
-    private Spinner spinnerTimeZones;
     private FieldSelector fieldSelector;
     private PlacesClient placesClient;
     private Place place;
@@ -57,24 +54,21 @@ public class PlaceIsOpenActivity extends AppCompatActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        setContentView(R.layout.place_is_open_activity);
+        binding = PlaceIsOpenActivityBinding.inflate(getLayoutInflater());
+        View rootView = binding.getRoot();
+        setContentView(rootView);
 
         // Retrieve a PlacesClient (previously initialized - see MainActivity)
         placesClient = Places.createClient(/* context= */ this);
 
-        textViewResponse = findViewById(R.id.textView_response);
-        spinnerTimeZones = findViewById(R.id.spinner_timeZones);
-        editTextIsOpenDate = findViewById(R.id.editText_isOpenDate);
-        editTextIsOpenTime = findViewById(R.id.editText_isOpenTime);
-
         fieldSelector =
                 new FieldSelector(
-                        findViewById(R.id.checkBox_useCustomFields),
-                        findViewById(R.id.textView_customFieldsList),
+                        binding.checkBoxUseCustomFields,
+                        binding.textViewCustomFieldsList,
                         savedInstanceState);
 
-        findViewById(R.id.button_fetchPlace).setOnClickListener(view -> fetchPlace());
-        findViewById(R.id.button_isOpen).setOnClickListener(view -> isOpenByPlaceId());
+        binding.buttonFetchPlace.setOnClickListener(view -> fetchPlace());
+        binding.buttonIsOpen.setOnClickListener(view -> isOpenByPlaceId());
 
         isOpenCalendar = Calendar.getInstance(TimeZone.getTimeZone(defaultTimeZone));
 
@@ -89,7 +83,7 @@ public class PlaceIsOpenActivity extends AppCompatActivity {
     }
 
     @Override
-    protected void onSaveInstanceState(Bundle bundle) {
+    protected void onSaveInstanceState(@NonNull Bundle bundle) {
         super.onSaveInstanceState(bundle);
         fieldSelector.onSaveInstanceState(bundle);
     }
@@ -99,7 +93,7 @@ public class PlaceIsOpenActivity extends AppCompatActivity {
      */
     private void fetchPlace() {
         clearViews();
-        dismissKeyboard(findViewById(R.id.editText_placeId));
+        dismissKeyboard(binding.editTextPlaceId);
         setLoading(true);
 
         List<Field> placeFields = getPlaceFields();
@@ -115,7 +109,7 @@ public class PlaceIsOpenActivity extends AppCompatActivity {
         placeTask.addOnFailureListener(
                 (exception) -> {
                     exception.printStackTrace();
-                    textViewResponse.setText(exception.getMessage());
+                    binding.textViewResponse.setText(exception.getMessage());
                 });
 
         placeTask.addOnCompleteListener(response -> setLoading(false));
@@ -128,7 +122,7 @@ public class PlaceIsOpenActivity extends AppCompatActivity {
     @SuppressLint("SetTextI18n")
     private void isOpenByPlaceObject(Place place) {
         clearViews();
-        dismissKeyboard(findViewById(R.id.editText_placeId));
+        dismissKeyboard(binding.editTextPlaceId);
         setLoading(true);
 
         IsOpenRequest request;
@@ -137,7 +131,7 @@ public class PlaceIsOpenActivity extends AppCompatActivity {
             request = IsOpenRequest.newInstance(place, isOpenCalendar.getTimeInMillis());
         } catch (IllegalArgumentException e) {
             e.printStackTrace();
-            textViewResponse.setText(e.getMessage());
+            binding.textViewResponse.setText(e.getMessage());
             setLoading(false);
             return;
         }
@@ -145,17 +139,15 @@ public class PlaceIsOpenActivity extends AppCompatActivity {
         Task<IsOpenResponse> placeTask = placesClient.isOpen(request);
 
         placeTask.addOnSuccessListener(
-                (response) -> {
-                    textViewResponse.setText("Is place open? "
-                                                     + response.isOpen()
-                                                     + "\nExtra place details: \n"
-                                                     + StringUtil.stringify(place));
-                });
+                (response) -> binding.textViewResponse.setText("Is place open? "
+                                                 + response.isOpen()
+                                                 + "\nExtra place details: \n"
+                                                 + StringUtil.stringify(place)));
 
         placeTask.addOnFailureListener(
                 (exception) -> {
                     exception.printStackTrace();
-                    textViewResponse.setText(exception.getMessage());
+                    binding.textViewResponse.setText(exception.getMessage());
                 });
 
         placeTask.addOnCompleteListener(response -> setLoading(false));
@@ -168,7 +160,7 @@ public class PlaceIsOpenActivity extends AppCompatActivity {
     @SuppressLint("SetTextI18n")
     private void isOpenByPlaceId() {
         clearViews();
-        dismissKeyboard(findViewById(R.id.editText_placeId));
+        dismissKeyboard(binding.editTextPlaceId);
         setLoading(true);
 
         IsOpenRequest request;
@@ -177,7 +169,7 @@ public class PlaceIsOpenActivity extends AppCompatActivity {
             request = IsOpenRequest.newInstance(getPlaceId(), isOpenCalendar.getTimeInMillis());
         } catch (IllegalArgumentException e) {
             e.printStackTrace();
-            textViewResponse.setText(e.getMessage());
+            binding.textViewResponse.setText(e.getMessage());
             setLoading(false);
             return;
         }
@@ -185,14 +177,12 @@ public class PlaceIsOpenActivity extends AppCompatActivity {
         Task<IsOpenResponse> placeTask = placesClient.isOpen(request);
 
         placeTask.addOnSuccessListener(
-                (response) -> {
-                    textViewResponse.setText("Is place open? " + response.isOpen());
-                });
+                (response) -> binding.textViewResponse.setText("Is place open? " + response.isOpen()));
 
         placeTask.addOnFailureListener(
                 (exception) -> {
                     exception.printStackTrace();
-                    textViewResponse.setText(exception.getMessage());
+                    binding.textViewResponse.setText(exception.getMessage());
                 });
 
         placeTask.addOnCompleteListener(response -> setLoading(false));
@@ -208,7 +198,7 @@ public class PlaceIsOpenActivity extends AppCompatActivity {
     }
 
     private String getPlaceId() {
-        return ((TextView) findViewById(R.id.editText_placeId)).getText().toString();
+        return ((TextView) binding.editTextPlaceId).getText().toString();
     }
 
     /**
@@ -216,10 +206,10 @@ public class PlaceIsOpenActivity extends AppCompatActivity {
      * select a custom list of fields. Also fetches name and address for display text.
      */
     private List<Field> getPlaceFields() {
-        if (((CheckBox) findViewById(R.id.checkBox_useCustomFields)).isChecked()) {
+        if (((CheckBox) binding.checkBoxUseCustomFields).isChecked()) {
             return fieldSelector.getSelectedFields();
         } else {
-            return new ArrayList<Field>(Arrays.asList(
+            return new ArrayList<>(Arrays.asList(
                     Field.ADDRESS,
                     Field.BUSINESS_STATUS,
                     Field.CURRENT_OPENING_HOURS,
@@ -232,20 +222,20 @@ public class PlaceIsOpenActivity extends AppCompatActivity {
     }
 
     private void setLoading(boolean loading) {
-        findViewById(R.id.progressBar_loading).setVisibility(loading ? View.VISIBLE : View.INVISIBLE);
+        binding.progressBarLoading.setVisibility(loading ? View.VISIBLE : View.INVISIBLE);
     }
 
     private void clearViews() {
-        textViewResponse.setText(null);
+        binding.textViewResponse.setText(null);
     }
 
     private void initializeSpinnerAndAddListener() {
         ArrayAdapter<String> adapter =
                 new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, TimeZone.getAvailableIDs());
-        spinnerTimeZones.setAdapter(adapter);
-        spinnerTimeZones.setSelection(adapter.getPosition(defaultTimeZone));
+        binding.spinnerTimeZones.setAdapter(adapter);
+        binding.spinnerTimeZones.setSelection(adapter.getPosition(defaultTimeZone));
 
-        spinnerTimeZones.setOnItemSelectedListener(
+        binding.spinnerTimeZones.setOnItemSelectedListener(
                 new OnItemSelectedListener() {
                     @Override
                     public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
@@ -270,21 +260,19 @@ public class PlaceIsOpenActivity extends AppCompatActivity {
                     updateIsOpenDate();
                 };
 
-        editTextIsOpenDate.setOnClickListener(
-                view -> {
-                    new DatePickerDialog(
-                            PlaceIsOpenActivity.this,
-                            listener,
-                            isOpenCalendar.get(Calendar.YEAR),
-                            isOpenCalendar.get(Calendar.MONTH),
-                            isOpenCalendar.get(Calendar.DAY_OF_MONTH))
-                            .show();
-                });
+        binding.editTextIsOpenDate.setOnClickListener(
+                view -> new DatePickerDialog(
+                        PlaceIsOpenActivity.this,
+                        listener,
+                        isOpenCalendar.get(Calendar.YEAR),
+                        isOpenCalendar.get(Calendar.MONTH),
+                        isOpenCalendar.get(Calendar.DAY_OF_MONTH))
+                        .show());
     }
 
     private void updateIsOpenDate() {
         SimpleDateFormat dateFormat = new SimpleDateFormat("MM/dd/yy", Locale.US);
-        editTextIsOpenDate.setText(dateFormat.format(isOpenCalendar.getTime()));
+        binding.editTextIsOpenDate.setText(dateFormat.format(isOpenCalendar.getTime()));
     }
 
     private void addIsOpenTimeSelectionListener() {
@@ -295,16 +283,14 @@ public class PlaceIsOpenActivity extends AppCompatActivity {
                     updateIsOpenTime();
                 };
 
-        editTextIsOpenTime.setOnClickListener(
-                view -> {
-                    new TimePickerDialog(
-                            PlaceIsOpenActivity.this,
-                            listener,
-                            isOpenCalendar.get(Calendar.HOUR_OF_DAY),
-                            isOpenCalendar.get(Calendar.MINUTE),
-                            true)
-                            .show();
-                });
+        binding.editTextIsOpenTime.setOnClickListener(
+                view -> new TimePickerDialog(
+                        PlaceIsOpenActivity.this,
+                        listener,
+                        isOpenCalendar.get(Calendar.HOUR_OF_DAY),
+                        isOpenCalendar.get(Calendar.MINUTE),
+                        true)
+                        .show());
     }
 
     private void updateIsOpenTime() {
@@ -312,7 +298,7 @@ public class PlaceIsOpenActivity extends AppCompatActivity {
                 String.format(Locale.getDefault(), "%02d", isOpenCalendar.get(Calendar.HOUR_OF_DAY));
         String formattedMinutes =
                 String.format(Locale.getDefault(), "%02d", isOpenCalendar.get(Calendar.MINUTE));
-        editTextIsOpenTime.setText(
+        binding.editTextIsOpenTime.setText(
                 String.format(Locale.getDefault(), "%s:%s", formattedHour, formattedMinutes));
     }
 }

--- a/demo-java/app/src/main/java/com/example/placesdemo/PlaceIsOpenActivity.java
+++ b/demo-java/app/src/main/java/com/example/placesdemo/PlaceIsOpenActivity.java
@@ -1,0 +1,240 @@
+package com.example.placesdemo;
+
+import android.annotation.SuppressLint;
+import android.app.DatePickerDialog;
+import android.app.TimePickerDialog;
+import android.content.Context;
+import android.os.Bundle;
+import androidx.appcompat.app.AppCompatActivity;
+import android.view.View;
+import android.view.inputmethod.InputMethodManager;
+import android.widget.ArrayAdapter;
+import android.widget.CheckBox;
+import android.widget.EditText;
+import android.widget.Spinner;
+import android.widget.TextView;
+import androidx.annotation.Nullable;
+import com.google.android.gms.tasks.Task;
+import com.google.android.libraries.places.api.Places;
+import com.google.android.libraries.places.api.model.Place;
+import com.google.android.libraries.places.api.model.Place.Field;
+import com.google.android.libraries.places.api.net.FetchPlaceRequest;
+import com.google.android.libraries.places.api.net.FetchPlaceResponse;
+import com.google.android.libraries.places.api.net.IsOpenRequest;
+import com.google.android.libraries.places.api.net.IsOpenResponse;
+import com.google.android.libraries.places.api.net.PlacesClient;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.List;
+import java.util.Locale;
+import java.util.TimeZone;
+
+/**
+ * Activity to demonstrate {@link PlacesClient#isOpen(IsOpenRequest)}.
+ */
+public class PlaceIsOpenActivity extends AppCompatActivity {
+
+    private final Calendar isOpenCalendar = Calendar.getInstance();
+
+    private EditText editTextIsOpenDate;
+    private EditText editTextIsOpenTime;
+    private TextView textViewResponse;
+    private Spinner spinnerTimeZones;
+    private FieldSelector fieldSelector;
+    private PlacesClient placesClient;
+    private Place place;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        setContentView(R.layout.place_is_open_activity);
+
+        // Retrieve a PlacesClient (previously initialized - see MainActivity)
+        placesClient = Places.createClient(/* context= */ this);
+
+        textViewResponse = findViewById(R.id.textView_response);
+        spinnerTimeZones = findViewById(R.id.spinner_timeZones);
+        editTextIsOpenDate = findViewById(R.id.editText_isOpenDate);
+        editTextIsOpenTime = findViewById(R.id.editText_isOpenTime);
+
+        fieldSelector =
+                new FieldSelector(
+                        findViewById(R.id.checkBox_useCustomFields),
+                        findViewById(R.id.textView_customFieldsList),
+                        savedInstanceState);
+
+        findViewById(R.id.button_fetchPlace).setOnClickListener(view -> fetchPlace());
+        findViewById(R.id.button_isOpen).setOnClickListener(view -> isOpen());
+
+        // UI initialization
+        setLoading(false);
+        initializeSpinnerTimeZones();
+        addIsOpenDateSelectionListener();
+        addIsOpenTimeSelectionListener();
+
+        updateIsOpenDate();
+        updateIsOpenTime();
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle bundle) {
+        super.onSaveInstanceState(bundle);
+        fieldSelector.onSaveInstanceState(bundle);
+    }
+
+    private void fetchPlace() {
+        clearViews();
+        dismissKeyboard(findViewById(R.id.editText_placeId));
+        setLoading(true);
+
+        List<Field> placeFields = getPlaceFields();
+        FetchPlaceRequest request = FetchPlaceRequest.newInstance(getPlaceId(), placeFields);
+        Task<FetchPlaceResponse> placeTask = placesClient.fetchPlace(request);
+
+        placeTask.addOnSuccessListener(
+                (response) -> {
+                    place = response.getPlace();
+                    textViewResponse.setText(StringUtil.stringify(response, isDisplayRawResultsChecked()));
+                });
+
+        placeTask.addOnFailureListener(
+                (exception) -> {
+                    exception.printStackTrace();
+                    textViewResponse.setText(exception.getMessage());
+                });
+
+        placeTask.addOnCompleteListener(response -> setLoading(false));
+    }
+
+    @SuppressLint("SetTextI18n")
+    private void isOpen() {
+        clearViews();
+        dismissKeyboard(findViewById(R.id.editText_placeId));
+        setLoading(true);
+
+        IsOpenRequest request;
+
+        try {
+            request =
+                    place != null
+                            ? IsOpenRequest.newInstance(place, isOpenCalendar.getTimeInMillis())
+                            : IsOpenRequest.newInstance(getPlaceId(), isOpenCalendar.getTimeInMillis());
+        } catch (IllegalArgumentException e) {
+            e.printStackTrace();
+            textViewResponse.setText(e.getMessage());
+            setLoading(false);
+            return;
+        }
+
+        Task<IsOpenResponse> placeTask = placesClient.isOpen(request);
+
+        placeTask.addOnSuccessListener(
+                (response) -> {
+                    textViewResponse.setText("Is place open? " + response.isOpen());
+                });
+
+        placeTask.addOnFailureListener(
+                (exception) -> {
+                    exception.printStackTrace();
+                    textViewResponse.setText(exception.getMessage());
+                });
+
+        placeTask.addOnCompleteListener(response -> setLoading(false));
+    }
+
+    //////////////////////////
+    // Helper methods below //
+    //////////////////////////
+
+    private void dismissKeyboard(EditText focusedEditText) {
+        InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+        imm.hideSoftInputFromWindow(focusedEditText.getWindowToken(), 0);
+    }
+
+    private String getPlaceId() {
+        return ((TextView) findViewById(R.id.editText_placeId)).getText().toString();
+    }
+
+    private List<Field> getPlaceFields() {
+        if (((CheckBox) findViewById(R.id.checkBox_useCustomFields)).isChecked()) {
+            return fieldSelector.getSelectedFields();
+        } else {
+            return fieldSelector.getAllFields();
+        }
+    }
+
+    private boolean isDisplayRawResultsChecked() {
+        return ((CheckBox) findViewById(R.id.checkBox_displayRawResults)).isChecked();
+    }
+
+    private void setLoading(boolean loading) {
+        findViewById(R.id.progressBar_loading).setVisibility(loading ? View.VISIBLE : View.INVISIBLE);
+    }
+
+    private void clearViews() {
+        textViewResponse.setText(null);
+    }
+
+    private void initializeSpinnerTimeZones() {
+        ArrayAdapter<String> adapter =
+                new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, TimeZone.getAvailableIDs());
+        spinnerTimeZones.setAdapter(adapter);
+        spinnerTimeZones.setSelection(adapter.getPosition("America/Los_Angeles"));
+    }
+
+    private void addIsOpenDateSelectionListener() {
+        DatePickerDialog.OnDateSetListener listener =
+                (view, year, month, day) -> {
+                    isOpenCalendar.set(Calendar.YEAR, year);
+                    isOpenCalendar.set(Calendar.MONTH, month);
+                    isOpenCalendar.set(Calendar.DAY_OF_MONTH, day);
+                    updateIsOpenDate();
+                };
+
+        editTextIsOpenDate.setOnClickListener(
+                view -> {
+                    new DatePickerDialog(
+                            IsOpenTestActivity.this,
+                            listener,
+                            isOpenCalendar.get(Calendar.YEAR),
+                            isOpenCalendar.get(Calendar.MONTH),
+                            isOpenCalendar.get(Calendar.DAY_OF_MONTH))
+                            .show();
+                });
+    }
+
+    private void updateIsOpenDate() {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("MM/dd/yy", Locale.US);
+        editTextIsOpenDate.setText(dateFormat.format(isOpenCalendar.getTime()));
+    }
+
+    private void addIsOpenTimeSelectionListener() {
+        TimePickerDialog.OnTimeSetListener listener =
+                (view, hourOfDay, minute) -> {
+                    isOpenCalendar.set(Calendar.HOUR_OF_DAY, hourOfDay);
+                    isOpenCalendar.set(Calendar.MINUTE, minute);
+                    updateIsOpenTime();
+                };
+
+        editTextIsOpenTime.setOnClickListener(
+                view -> {
+                    new TimePickerDialog(
+                            IsOpenTestActivity.this,
+                            listener,
+                            isOpenCalendar.get(Calendar.HOUR_OF_DAY),
+                            isOpenCalendar.get(Calendar.MINUTE),
+                            true)
+                            .show();
+                });
+    }
+
+    private void updateIsOpenTime() {
+        String formattedHour =
+                String.format(Locale.getDefault(), "%02d", isOpenCalendar.get(Calendar.HOUR_OF_DAY));
+        String formattedMinutes =
+                String.format(Locale.getDefault(), "%02d", isOpenCalendar.get(Calendar.MINUTE));
+        editTextIsOpenTime.setText(
+                String.format(Locale.getDefault(), "%s:%s", formattedHour, formattedMinutes));
+    }
+}

--- a/demo-java/app/src/main/java/com/example/placesdemo/StringUtil.java
+++ b/demo-java/app/src/main/java/com/example/placesdemo/StringUtil.java
@@ -16,6 +16,12 @@
 
 package com.example.placesdemo;
 
+import android.graphics.Bitmap;
+import android.text.TextUtils;
+import android.widget.TextView;
+
+import androidx.annotation.Nullable;
+
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
 import com.google.android.libraries.places.api.model.AutocompletePrediction;
@@ -25,13 +31,6 @@ import com.google.android.libraries.places.api.net.FetchPlaceResponse;
 import com.google.android.libraries.places.api.net.FindAutocompletePredictionsResponse;
 import com.google.android.libraries.places.api.net.FindCurrentPlaceResponse;
 
-import android.graphics.Bitmap;
-import android.text.TextUtils;
-import android.widget.TextView;
-
-import androidx.annotation.Nullable;
-
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -78,12 +77,11 @@ public final class StringUtil {
   }
 
   static List<String> countriesStringToArrayList(String countriesString) {
+
     // Allow these delimiters: , ; | / \
-    List<String> countries = Arrays.asList(countriesString
+    return Arrays.asList(countriesString
             .replaceAll("\\s", "|")
             .split("[,;|/\\\\]",-1));
-
-    return countries;
   }
 
   static String stringify(FindAutocompletePredictionsResponse response, boolean raw) {
@@ -147,9 +145,7 @@ public final class StringUtil {
     return place.getName()
             + " ("
             + place.getAddress()
-            + ")"
-            + " is open now? "
-            + place.isOpen(System.currentTimeMillis());
+            + ")";
   }
 
   static String stringify(Bitmap bitmap) {

--- a/demo-java/app/src/main/java/com/example/placesdemo/model/GeocodingResult.java
+++ b/demo-java/app/src/main/java/com/example/placesdemo/model/GeocodingResult.java
@@ -14,6 +14,8 @@
 
 package com.example.placesdemo.model;
 
+import androidx.annotation.NonNull;
+
 import java.io.Serializable;
 import java.util.Arrays;
 
@@ -71,6 +73,7 @@ public class GeocodingResult implements Serializable {
     /** The Plus Code identifier for this place. */
     public PlusCode plusCode;
 
+    @NonNull
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder("[GeocodingResult");

--- a/demo-java/app/src/main/java/com/example/placesdemo/model/Geometry.java
+++ b/demo-java/app/src/main/java/com/example/placesdemo/model/Geometry.java
@@ -14,7 +14,10 @@
 
 package com.example.placesdemo.model;
 
+import androidx.annotation.NonNull;
+
 import com.google.android.gms.maps.model.LatLng;
+
 import java.io.Serializable;
 
 /** The geometry of a Geocoding result. */
@@ -44,6 +47,7 @@ public class Geometry implements Serializable {
    */
   public Bounds viewport;
 
+  @NonNull
   @Override
   public String toString() {
     return String.format(

--- a/demo-java/app/src/main/java/com/example/placesdemo/programmatic_autocomplete/ProgrammaticAutocompleteToolbarActivity.java
+++ b/demo-java/app/src/main/java/com/example/placesdemo/programmatic_autocomplete/ProgrammaticAutocompleteToolbarActivity.java
@@ -23,6 +23,7 @@ import android.widget.ProgressBar;
 import android.widget.SearchView;
 import android.widget.SearchView.OnQueryTextListener;
 import android.widget.ViewAnimator;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
@@ -30,6 +31,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
+
 import com.android.volley.Request.Method;
 import com.android.volley.RequestQueue;
 import com.android.volley.toolbox.JsonObjectRequest;
@@ -50,17 +52,18 @@ import com.google.android.libraries.places.api.net.PlacesClient;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
-import java.util.Arrays;
-import java.util.List;
 import org.json.JSONArray;
 import org.json.JSONException;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * An Activity that demonstrates programmatic as-you-type place predictions. The parameters of the
  * request are currently hard coded in this Activity, to modify these parameters (e.g. location
  * bias, place types, etc.), see {@link ProgrammaticAutocompleteToolbarActivity#getPlacePredictions(String)}.
  *
- * @see https://developers.google.com/places/android-sdk/autocomplete#get_place_predictions_programmatically
+ * @see <a href="https://developers.google.com/places/android-sdk/autocomplete#get_place_predictions_programmatically">documentation</a>
  */
 public class ProgrammaticAutocompleteToolbarActivity extends AppCompatActivity {
 
@@ -194,7 +197,7 @@ public class ProgrammaticAutocompleteToolbarActivity extends AppCompatActivity {
     /**
      * Performs a Geocoding API request and displays the result in a dialog.
      *
-     * @see https://developers.google.com/maps/documentation/geocoding/intro
+     * @see <a href="https://developers.google.com/maps/documentation/geocoding/intro">documentation</a>
      */
     private void geocodePlaceAndDisplay(AutocompletePrediction placePrediction) {
         // Construct the request URL

--- a/demo-java/app/src/main/java/com/example/placesdemo/programmatic_autocomplete/ProgrammaticAutocompleteToolbarActivity.java
+++ b/demo-java/app/src/main/java/com/example/placesdemo/programmatic_autocomplete/ProgrammaticAutocompleteToolbarActivity.java
@@ -49,6 +49,8 @@ import com.google.android.libraries.places.api.net.FindAutocompletePredictionsRe
 import com.google.android.libraries.places.api.net.PlacesClient;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+
+import java.util.Arrays;
 import java.util.List;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -170,7 +172,7 @@ public class ProgrammaticAutocompleteToolbarActivity extends AppCompatActivity {
             .setLocationBias(bias)
             .setTypeFilter(TypeFilter.ESTABLISHMENT)
             .setQuery(query)
-            .setCountries("IN")
+            .setCountries(Arrays.asList("IN"))
             .build();
 
         // Perform autocomplete predictions request

--- a/demo-java/app/src/main/java/com/example/placesdemo/programmatic_autocomplete/ProgrammaticAutocompleteToolbarActivity.java
+++ b/demo-java/app/src/main/java/com/example/placesdemo/programmatic_autocomplete/ProgrammaticAutocompleteToolbarActivity.java
@@ -45,8 +45,8 @@ import com.google.android.libraries.places.api.Places;
 import com.google.android.libraries.places.api.model.AutocompletePrediction;
 import com.google.android.libraries.places.api.model.AutocompleteSessionToken;
 import com.google.android.libraries.places.api.model.LocationBias;
+import com.google.android.libraries.places.api.model.PlaceTypes;
 import com.google.android.libraries.places.api.model.RectangularBounds;
-import com.google.android.libraries.places.api.model.TypeFilter;
 import com.google.android.libraries.places.api.net.FindAutocompletePredictionsRequest;
 import com.google.android.libraries.places.api.net.PlacesClient;
 import com.google.gson.Gson;
@@ -68,10 +68,10 @@ import java.util.List;
 public class ProgrammaticAutocompleteToolbarActivity extends AppCompatActivity {
 
     private static final String TAG = ProgrammaticAutocompleteToolbarActivity.class.getSimpleName();
-    private Handler handler = new Handler();
-    private PlacePredictionAdapter adapter = new PlacePredictionAdapter();
-    private Gson gson = new GsonBuilder().registerTypeAdapter(LatLng.class, new LatLngAdapter())
-        .create();
+    private final Handler handler = new Handler();
+    private final PlacePredictionAdapter adapter = new PlacePredictionAdapter();
+    private final Gson gson = new GsonBuilder().registerTypeAdapter(LatLng.class, new LatLngAdapter())
+            .create();
 
     private RequestQueue queue;
     private PlacesClient placesClient;
@@ -99,7 +99,7 @@ public class ProgrammaticAutocompleteToolbarActivity extends AppCompatActivity {
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.menu, menu);
         final SearchView searchView =
-            (SearchView) menu.findItem(R.id.search).getActionView();
+                (SearchView) menu.findItem(R.id.search).getActionView();
         initSearchView(searchView);
         return super.onCreateOptionsMenu(menu);
     }
@@ -133,9 +133,7 @@ public class ProgrammaticAutocompleteToolbarActivity extends AppCompatActivity {
                 handler.removeCallbacksAndMessages(null);
 
                 // Start a new place prediction request in 300 ms
-                handler.postDelayed(() -> {
-                    getPlacePredictions(newText);
-                }, 300);
+                handler.postDelayed(() -> getPlacePredictions(newText), 300);
                 return true;
             }
         });
@@ -147,7 +145,7 @@ public class ProgrammaticAutocompleteToolbarActivity extends AppCompatActivity {
         recyclerView.setLayoutManager(layoutManager);
         recyclerView.setAdapter(adapter);
         recyclerView
-            .addItemDecoration(new DividerItemDecoration(this, layoutManager.getOrientation()));
+                .addItemDecoration(new DividerItemDecoration(this, layoutManager.getOrientation()));
         adapter.setPlaceClickListener(this::geocodePlaceAndDisplay);
     }
 
@@ -164,19 +162,19 @@ public class ProgrammaticAutocompleteToolbarActivity extends AppCompatActivity {
         // pass in the appropriate value/s for .setCountries() in the
         // FindAutocompletePredictionsRequest.Builder object as well.
         final LocationBias bias = RectangularBounds.newInstance(
-            new LatLng(22.458744, 88.208162), // SW lat, lng
-            new LatLng(22.730671, 88.524896) // NE lat, lng
+                new LatLng(22.458744, 88.208162), // SW lat, lng
+                new LatLng(22.730671, 88.524896) // NE lat, lng
         );
 
         // Create a new programmatic Place Autocomplete request in Places SDK for Android
         final FindAutocompletePredictionsRequest newRequest = FindAutocompletePredictionsRequest
-            .builder()
-            .setSessionToken(sessionToken)
-            .setLocationBias(bias)
-            .setTypeFilter(TypeFilter.ESTABLISHMENT)
-            .setQuery(query)
-            .setCountries(Arrays.asList("IN"))
-            .build();
+                .builder()
+                .setSessionToken(sessionToken)
+                .setLocationBias(bias)
+                .setQuery(query)
+                .setCountries(Arrays.asList("IN"))
+                .setTypesFilter(Arrays.asList(PlaceTypes.ESTABLISHMENT))
+                .build();
 
         // Perform autocomplete predictions request
         placesClient.findAutocompletePredictions(newRequest).addOnSuccessListener((response) -> {
@@ -207,23 +205,23 @@ public class ProgrammaticAutocompleteToolbarActivity extends AppCompatActivity {
 
         // Use the HTTP request URL for Geocoding API to get geographic coordinates for the place
         JsonObjectRequest request = new JsonObjectRequest(Method.GET, requestURL, null,
-            response -> {
-                try {
-                    // Inspect the value of "results" and make sure it's not empty
-                    JSONArray results = response.getJSONArray("results");
-                    if (results.length() == 0) {
-                        Log.w(TAG, "No results from geocoding request.");
-                        return;
-                    }
+                                                          response -> {
+                                                              try {
+                                                                  // Inspect the value of "results" and make sure it's not empty
+                                                                  JSONArray results = response.getJSONArray("results");
+                                                                  if (results.length() == 0) {
+                                                                      Log.w(TAG, "No results from geocoding request.");
+                                                                      return;
+                                                                  }
 
-                    // Use Gson to convert the response JSON object to a POJO
-                    GeocodingResult result = gson.fromJson(
-                        results.getString(0), GeocodingResult.class);
-                    displayDialog(placePrediction, result);
-                } catch (JSONException e) {
-                    e.printStackTrace();
-                }
-            }, error -> Log.e(TAG, "Request failed"));
+                                                                  // Use Gson to convert the response JSON object to a POJO
+                                                                  GeocodingResult result = gson.fromJson(
+                                                                          results.getString(0), GeocodingResult.class);
+                                                                  displayDialog(placePrediction, result);
+                                                              } catch (JSONException e) {
+                                                                  e.printStackTrace();
+                                                              }
+                                                          }, error -> Log.e(TAG, "Request failed"));
 
         // Add the request to the Request queue.
         queue.add(request);
@@ -231,9 +229,9 @@ public class ProgrammaticAutocompleteToolbarActivity extends AppCompatActivity {
 
     private void displayDialog(AutocompletePrediction place, GeocodingResult result) {
         new AlertDialog.Builder(this)
-            .setTitle(place.getPrimaryText(null))
-            .setMessage("Geocoding result:\n" + result.geometry.location)
-            .setPositiveButton(android.R.string.ok, null)
-            .show();
+                .setTitle(place.getPrimaryText(null))
+                .setMessage("Geocoding result:\n" + result.geometry.location)
+                .setPositiveButton(android.R.string.ok, null)
+                .show();
     }
 }

--- a/demo-java/app/src/main/res/layout/activity_main.xml
+++ b/demo-java/app/src/main/res/layout/activity_main.xml
@@ -44,6 +44,13 @@
       android:layout_height="wrap_content"
       android:layout_margin="@dimen/spacing_small"
       android:text="@string/programmatic_autocomplete_geocoding_button"/>
+
+  <Button
+      android:id="@+id/current_place_button"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_margin="@dimen/spacing_small"
+      android:text="@string/current_place_button"/>
   
   <Button
       android:id="@+id/place_and_photo_button"
@@ -54,17 +61,10 @@
 
   <Button
       android:id="@+id/is_open_button"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_margin="@dimen/spacing_small"
-      android:text="@string/main_isOpenButtonText"/>
-
-  <Button
-      android:id="@+id/current_place_button"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_margin="@dimen/spacing_small"
-      android:text="@string/current_place_button"/>
+      android:text="@string/main_isOpenButtonText"/>
 
 </LinearLayout>
 

--- a/demo-java/app/src/main/res/layout/activity_main.xml
+++ b/demo-java/app/src/main/res/layout/activity_main.xml
@@ -53,6 +53,13 @@
       android:text="@string/place_and_photo_button"/>
 
   <Button
+      android:id="@+id/is_open_button"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_margin="@dimen/spacing_small"
+      android:text="@string/main_isOpenButtonText"/>
+
+  <Button
       android:id="@+id/current_place_button"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"

--- a/demo-java/app/src/main/res/layout/autocomplete_address_map.xml
+++ b/demo-java/app/src/main/res/layout/autocomplete_address_map.xml
@@ -28,7 +28,7 @@
     <!-- A map will be added here programmatically
     for visual confirmation of the selected address -->
     <!-- [START maps_solutions_android_autocomplete_map_fragment] -->
-    <fragment xmlns:android="http://schemas.android.com/apk/res/android"
+    <fragment
         android:name="com.google.android.gms.maps.SupportMapFragment"
         android:id="@+id/confirmation_map"
         android:layout_width="match_parent"

--- a/demo-java/app/src/main/res/layout/current_place_activity.xml
+++ b/demo-java/app/src/main/res/layout/current_place_activity.xml
@@ -66,7 +66,6 @@
         style="?android:attr/progressBarStyleSmall"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_centerHorizontal="true"
         android:visibility="invisible"/>
 
     <TextView

--- a/demo-java/app/src/main/res/layout/place_autocomplete_activity.xml
+++ b/demo-java/app/src/main/res/layout/place_autocomplete_activity.xml
@@ -58,6 +58,7 @@
           android:id="@+id/autocomplete_location_bias_south_west"
           android:layout_width="0dp"
           android:layout_height="wrap_content"
+          android:minHeight="48dp"
           android:layout_weight="1"
           android:hint="@string/autocomplete_location_south_west_hint"
           android:autofillHints=""
@@ -89,6 +90,7 @@
           android:id="@+id/autocomplete_location_restriction_south_west"
           android:layout_width="0dp"
           android:layout_height="wrap_content"
+          android:minHeight="48dp"
           android:layout_weight="1"
           android:hint="@string/autocomplete_location_south_west_hint"
           android:autofillHints=""
@@ -143,6 +145,7 @@
           android:id="@+id/autocomplete_use_types_filter_checkbox"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
+          android:minHeight="48dp"
           android:checked="false"
           android:text="@string/autocomplete_use_types_filter"/>
 
@@ -157,29 +160,12 @@
 
     </LinearLayout>
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-      <CheckBox
-          android:id="@+id/autocomplete_use_type_filter"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:checked="false"
-          android:text="@string/autocomplete_use_type_filter"/>
-
-      <Spinner
-          android:id="@+id/autocomplete_type_filter"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"/>
-    </LinearLayout>
-
     <!-- Autocomplete predictions only -->
     <CheckBox
         android:id="@+id/autocomplete_use_session_token"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:minHeight="48dp"
         android:checked="false"
         android:text="@string/autocomplete_use_session_token"/>
 
@@ -188,6 +174,7 @@
         android:id="@+id/autocomplete_activity_overlay_mode"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:minHeight="48dp"
         android:checked="false"
         android:text="@string/autocomplete_activity_overlay_mode"/>
 
@@ -198,9 +185,9 @@
 
       <CheckBox
           android:id="@+id/use_custom_fields"
-          android:layout_width="0dp"
+          android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_weight="1"
+          android:minHeight="48dp"
           android:text="@string/use_custom_fields"/>
 
       <TextView
@@ -230,11 +217,12 @@
         android:id="@+id/autocomplete_support_fragment_text_label"
         android:text="@string/autocomplete_support_fragment_text_label"/>
 
-    <fragment
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/autocomplete_support_fragment"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:name="com.google.android.libraries.places.widget.AutocompleteSupportFragment"/>
+        android:name="com.google.android.libraries.places.widget.AutocompleteSupportFragment"
+        tools:layout="@layout/places_autocomplete_fragment" />
 
     <Button
         android:id="@+id/autocomplete_support_fragment_update_button"
@@ -255,7 +243,6 @@
         style="?android:attr/progressBarStyleSmall"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_centerHorizontal="true"
         android:visibility="invisible"/>
 
     <TextView

--- a/demo-java/app/src/main/res/layout/place_details_and_photos_activity.xml
+++ b/demo-java/app/src/main/res/layout/place_details_and_photos_activity.xml
@@ -38,7 +38,7 @@
         android:autofillHints=""
         android:imeOptions="actionGo"
         android:inputType="text"
-        android:text="@string/place_id_SFO"/>
+        android:text="@string/place_id_default"/>
 
     <CheckBox
         android:id="@+id/fetch_photo_checkbox"

--- a/demo-java/app/src/main/res/layout/place_details_and_photos_activity.xml
+++ b/demo-java/app/src/main/res/layout/place_details_and_photos_activity.xml
@@ -169,7 +169,6 @@
           style="?android:attr/progressBarStyleSmall"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_centerHorizontal="true"
           android:visibility="invisible"/>
 
     </LinearLayout>

--- a/demo-java/app/src/main/res/layout/place_is_open_activity.xml
+++ b/demo-java/app/src/main/res/layout/place_is_open_activity.xml
@@ -32,6 +32,7 @@
         android:id="@+id/editText_placeId"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:minHeight="48dp"
         android:hint="@string/isOpen_placeIdHint"
         android:autofillHints=""
         android:imeOptions="actionGo"
@@ -47,6 +48,7 @@
           android:id="@+id/checkBox_useCustomFields"
           android:layout_width="0dp"
           android:layout_height="wrap_content"
+          android:minHeight="48dp"
           android:layout_weight="1"
           android:text="@string/isOpen_useCustomFieldsText"/>
 
@@ -81,6 +83,7 @@
             android:id="@+id/spinner_timeZones"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:minHeight="48dp"
             android:layout_weight="7"
             android:padding="10dp" />
 
@@ -121,26 +124,21 @@
 
       <Button
           android:id="@+id/button_fetchPlace"
-          android:layout_width="wrap_content"
+          android:layout_width="0dp"
           android:layout_height="wrap_content"
+          android:layout_weight="1"
           android:text="@string/isOpen_fetchPlaceButtonText"
           tools:ignore="ButtonStyle" />
 
       <Button
           android:id="@+id/button_isOpen"
-          android:layout_width="wrap_content"
+          android:layout_width="0dp"
           android:layout_height="wrap_content"
+          android:layout_weight="1"
           android:text="@string/isOpen_isOpenButtonText"
           tools:ignore="ButtonStyle" />
 
     </LinearLayout>
-
-    <CheckBox
-        android:id="@+id/checkBox_displayRawResults"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:checked="false"
-        android:text="@string/isOpen_displayRawResults"/>
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/demo-java/app/src/main/res/layout/place_is_open_activity.xml
+++ b/demo-java/app/src/main/res/layout/place_is_open_activity.xml
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ Copyright 2020 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_margin="@dimen/spacing_large"
+    tools:context=".PlaceIsOpenActivity">
+
+  <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:orientation="vertical">
+
+    <EditText
+        android:id="@+id/editText_placeId"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/isOpen_placeIdHint"
+        android:autofillHints=""
+        android:imeOptions="actionGo"
+        android:inputType="text"
+        android:text="@string/isOpen_defaultPlaceId"/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+      <CheckBox
+          android:id="@+id/checkBox_useCustomFields"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:layout_weight="1"
+          android:text="@string/isOpen_useCustomFieldsText"/>
+
+      <TextView
+          android:id="@+id/textView_customFieldsList"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:layout_weight="1"/>
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_xlarge"
+        android:layout_marginBottom="@dimen/spacing_xlarge"
+        android:orientation="vertical">
+
+      <LinearLayout
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:orientation="horizontal"
+          android:weightSum="10">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="3"
+            android:text="@string/isOpen_spinnerDescription"/>
+
+        <Spinner
+            android:id="@+id/spinner_timeZones"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="7"
+            android:padding="10dp" />
+
+      </LinearLayout>
+
+      <EditText
+          android:id="@+id/editText_isOpenDate"
+          android:autofillHints=""
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:clickable="false"
+          android:cursorVisible="false"
+          android:focusable="false"
+          android:focusableInTouchMode="false"
+          android:longClickable="false"
+          android:hint="@string/isOpen_dateHint"
+          android:inputType="date" />
+
+      <EditText
+          android:id="@+id/editText_isOpenTime"
+          android:autofillHints=""
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:clickable="false"
+          android:cursorVisible="false"
+          android:focusable="false"
+          android:focusableInTouchMode="false"
+          android:longClickable="false"
+          android:hint="@string/isOpen_timeHint"
+          android:inputType="time" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+      <Button
+          android:id="@+id/button_fetchPlace"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/isOpen_fetchPlaceButtonText"
+          tools:ignore="ButtonStyle" />
+
+      <Button
+          android:id="@+id/button_isOpen"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/isOpen_isOpenButtonText"
+          tools:ignore="ButtonStyle" />
+
+    </LinearLayout>
+
+    <CheckBox
+        android:id="@+id/checkBox_displayRawResults"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:checked="false"
+        android:text="@string/isOpen_displayRawResults"/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+      <ProgressBar
+          android:id="@+id/progressBar_loading"
+          style="?android:attr/progressBarStyleSmall"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:visibility="invisible"/>
+
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/textView_response"
+        android:freezesText="true"
+        android:textIsSelectable="true"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"/>
+
+  </LinearLayout>
+
+</ScrollView>

--- a/demo-java/app/src/main/res/layout/place_is_open_activity.xml
+++ b/demo-java/app/src/main/res/layout/place_is_open_activity.xml
@@ -33,11 +33,11 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:minHeight="48dp"
-        android:hint="@string/isOpen_placeIdHint"
+        android:hint="@string/isOpen_place_id_hint"
         android:autofillHints=""
         android:imeOptions="actionGo"
         android:inputType="text"
-        android:text="@string/isOpen_defaultPlaceId"/>
+        android:text="@string/isOpen_default_place_id"/>
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -50,7 +50,7 @@
           android:layout_height="wrap_content"
           android:minHeight="48dp"
           android:layout_weight="1"
-          android:text="@string/isOpen_useCustomFieldsText"/>
+          android:text="@string/isOpen_use_custom_fields_text"/>
 
       <TextView
           android:id="@+id/textView_customFieldsList"
@@ -70,7 +70,7 @@
       <TextView
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:text="@string/isOpen_useCustomTimeHint" />
+          android:text="@string/isOpen_use_custom_time_hint" />
 
       <LinearLayout
           android:layout_width="match_parent"
@@ -82,7 +82,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="3"
-            android:text="@string/isOpen_spinnerDescription"/>
+            android:text="@string/isOpen_spinner_description"/>
 
         <Spinner
             android:id="@+id/spinner_timeZones"
@@ -104,7 +104,7 @@
           android:focusable="false"
           android:focusableInTouchMode="false"
           android:longClickable="false"
-          android:hint="@string/isOpen_dateHint"
+          android:hint="@string/isOpen_date_hint"
           android:inputType="date" />
 
       <EditText
@@ -117,7 +117,7 @@
           android:focusable="false"
           android:focusableInTouchMode="false"
           android:longClickable="false"
-          android:hint="@string/isOpen_timeHint"
+          android:hint="@string/isOpen_time_hint"
           android:inputType="time" />
 
     </LinearLayout>
@@ -132,7 +132,7 @@
           android:layout_width="0dp"
           android:layout_height="wrap_content"
           android:layout_weight="1"
-          android:text="@string/isOpen_fetchPlaceButtonText"
+          android:text="@string/isOpen_fetch_place_button_text"
           tools:ignore="ButtonStyle" />
 
       <Button
@@ -140,7 +140,7 @@
           android:layout_width="0dp"
           android:layout_height="wrap_content"
           android:layout_weight="1"
-          android:text="@string/isOpen_isOpenButtonText"
+          android:text="@string/isOpen_is_open_button_text"
           tools:ignore="ButtonStyle" />
 
     </LinearLayout>

--- a/demo-java/app/src/main/res/layout/place_is_open_activity.xml
+++ b/demo-java/app/src/main/res/layout/place_is_open_activity.xml
@@ -67,6 +67,11 @@
         android:layout_marginBottom="@dimen/spacing_xlarge"
         android:orientation="vertical">
 
+      <TextView
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:text="@string/isOpen_useCustomTimeHint" />
+
       <LinearLayout
           android:layout_width="match_parent"
           android:layout_height="wrap_content"

--- a/demo-java/app/src/main/res/values/dimens.xml
+++ b/demo-java/app/src/main/res/values/dimens.xml
@@ -15,6 +15,7 @@
 -->
 
 <resources>
+  <dimen name="spacing_xlarge">8dp</dimen>
   <dimen name="spacing_large">4dp</dimen>
   <dimen name="spacing_small">2dp</dimen>
 </resources>

--- a/demo-java/app/src/main/res/values/strings.xml
+++ b/demo-java/app/src/main/res/values/strings.xml
@@ -50,6 +50,8 @@
   <!-- Button for launching current place test activity. -->
   <string name="current_place_button" translatable="false">Current Place</string>
 
+  <!-- Button for launching is open test activity. -->
+  <string name="main_isOpenButtonText" translatable="false">Place is Open?</string>
 
   <!-- AUTOCOMPLETE TEST -->
 
@@ -223,4 +225,17 @@
   <string name="search_a_place">Search a Place</string>
   <string name="programmatic_place_predictions_instructions">This activity demonstrates as-you-type programmatic place predictions. Tap on the search icon on the toolbar and search for a place.</string>
 
+
+  <!-- IS OPEN -->
+  <string name="isOpen_fetchPlaceButtonText" translatable="false">Fetch Place</string>
+  <string name="isOpen_isOpenButtonText" translatable="false">Is Open</string>
+  <string name="isOpen_placeIdHint" translatable="false">Enter place ID</string>
+  <string name="isOpen_useCustomFieldsText" translatable="false">Manually set Place Fields?</string>
+  <string name="isOpen_spinnerDescription" translatable="false">Time Zone</string>
+  <string name="isOpen_dateHint" translatable="false">Select isOpen date</string>
+  <string name="isOpen_timeHint" translatable="false">Select isOpen time</string>
+  <string name="isOpen_useCustomTimeHint" translatable="false">Use custom isOpen time? (must set time zone, date, and time)</string>
+  <string name="isOpen_defaultPlaceId" translatable="false">ChIJ0yqxBq23j4AR53Q9SzIY52A</string>
+  <string name="isOpen_resultDescription" translatable="false">Is Place Open?</string>
+  <string name="isOpen_displayRawResults" translatable="false">Display raw results?</string>
 </resources>

--- a/demo-java/app/src/main/res/values/strings.xml
+++ b/demo-java/app/src/main/res/values/strings.xml
@@ -229,6 +229,5 @@
   <string name="isOpen_timeHint" translatable="false">Select isOpen time</string>
   <string name="isOpen_useCustomTimeHint" translatable="false">Use custom isOpen time? (must set time zone, date, and time)</string>
   <string name="isOpen_defaultPlaceId" translatable="false">ChIJD3uTd9hx5kcR1IQvGfr8dbk</string>
-  <string name="isOpen_resultDescription" translatable="false">Is Place Open?</string>
 
 </resources>

--- a/demo-java/app/src/main/res/values/strings.xml
+++ b/demo-java/app/src/main/res/values/strings.xml
@@ -181,7 +181,7 @@
   <!-- Text for the toast message for a skilled proximity match. -->
   <string name="autocomplete_skipped_message" translatable="false">Address accepted without checking proximity</string>
 
-  <!-- FETCH PLACE AND PHOTO -->
+  <!-- FETCH PLACE DETAILS AND PHOTO -->
 
   <!-- Hint for the place ID field. -->
   <string name="place_id_field_hint" translatable="false">Enter place ID</string>
@@ -207,6 +207,18 @@
   <!-- Text for the fetch place and photo button. -->
   <string name="fetch_place_and_photo_button" translatable="false">Fetch Place and Photo</string>
 
+  <!-- PLACE IS OPEN -->
+  <string name="isOpen_fetchPlaceButtonText" translatable="false">Fetch Place</string>
+  <string name="isOpen_isOpenButtonText" translatable="false">Is Open</string>
+  <string name="isOpen_placeIdHint" translatable="false">Enter place ID</string>
+  <string name="isOpen_useCustomFieldsText" translatable="false">Manually set Place Fields?</string>
+  <string name="isOpen_spinnerDescription" translatable="false">Time Zone</string>
+  <string name="isOpen_dateHint" translatable="false">Select isOpen date</string>
+  <string name="isOpen_timeHint" translatable="false">Select isOpen time</string>
+  <string name="isOpen_useCustomTimeHint" translatable="false">Use custom isOpen time? (must set time zone, date, and time)</string>
+  <string name="isOpen_defaultPlaceId" translatable="false">ChIJ0yqxBq23j4AR53Q9SzIY52A</string>
+  <string name="isOpen_resultDescription" translatable="false">Is Place Open?</string>
+  <string name="isOpen_displayRawResults" translatable="false">Display raw results?</string>
 
   <!-- FIND CURRENT PLACE -->
 
@@ -225,17 +237,4 @@
   <string name="search_a_place">Search a Place</string>
   <string name="programmatic_place_predictions_instructions">This activity demonstrates as-you-type programmatic place predictions. Tap on the search icon on the toolbar and search for a place.</string>
 
-
-  <!-- IS OPEN -->
-  <string name="isOpen_fetchPlaceButtonText" translatable="false">Fetch Place</string>
-  <string name="isOpen_isOpenButtonText" translatable="false">Is Open</string>
-  <string name="isOpen_placeIdHint" translatable="false">Enter place ID</string>
-  <string name="isOpen_useCustomFieldsText" translatable="false">Manually set Place Fields?</string>
-  <string name="isOpen_spinnerDescription" translatable="false">Time Zone</string>
-  <string name="isOpen_dateHint" translatable="false">Select isOpen date</string>
-  <string name="isOpen_timeHint" translatable="false">Select isOpen time</string>
-  <string name="isOpen_useCustomTimeHint" translatable="false">Use custom isOpen time? (must set time zone, date, and time)</string>
-  <string name="isOpen_defaultPlaceId" translatable="false">ChIJ0yqxBq23j4AR53Q9SzIY52A</string>
-  <string name="isOpen_resultDescription" translatable="false">Is Place Open?</string>
-  <string name="isOpen_displayRawResults" translatable="false">Display raw results?</string>
 </resources>

--- a/demo-java/app/src/main/res/values/strings.xml
+++ b/demo-java/app/src/main/res/values/strings.xml
@@ -44,16 +44,16 @@
   <!-- Button for launching autocomplete address form activity. -->
   <string name="programmatic_autocomplete_geocoding_button">Programmatic Autocomplete + Geocoding</string>
 
-  <!-- Button for launching place and photo test activity. -->
-  <string name="place_and_photo_button" translatable="false">Place Details and Place Photos</string>
-
   <!-- Button for launching current place test activity. -->
   <string name="current_place_button" translatable="false">Current Place</string>
+
+  <!-- Button for launching place and photo test activity. -->
+  <string name="place_and_photo_button" translatable="false">Place Details and Place Photos</string>
 
   <!-- Button for launching is open test activity. -->
   <string name="main_isOpenButtonText" translatable="false">Place is Open?</string>
 
-  <!-- AUTOCOMPLETE TEST -->
+  <!-- AUTOCOMPLETE -->
 
   <!-- Hint for the autocomplete widget's initial query and autocomplete prediction's query field. -->
   <string name="autocomplete_query_hint" translatable="false">(Initial) Query</string>
@@ -91,16 +91,6 @@
       Comma separated list of up to 5 place types
     </font>
   </string>
-
-  <!-- KEEP UNTIL v3 REMOVED -->
-
-  <!-- Text for enabling autocomplete prediction's and widget's type filter field. -->
-  <string name="autocomplete_use_type_filter" translatable="false">Use TypeFilter? (Deprecated)</string>
-
-    <!-- Hint Text for the autocomplete prediction's and widget's type filter field. -->
-  <string name="autocomplete_type_filter" translatable="false">Type Filter</string>
-
-  <!-- END KEEP UNTIL v3 REMOVED -->
 
 
   <!-- Text for enabling autocomplete prediction's use of session tokens. -->
@@ -181,7 +171,28 @@
   <!-- Text for the toast message for a skilled proximity match. -->
   <string name="autocomplete_skipped_message" translatable="false">Address accepted without checking proximity</string>
 
-  <!-- FETCH PLACE DETAILS AND PHOTO -->
+  <!-- PROGRAMMATIC AUTOCOMPLETE AND GEOCODING -->
+
+  <string name="search">Search</string>
+  <string name="search_a_place">Search a Place</string>
+  <string name="programmatic_place_predictions_instructions">This activity demonstrates as-you-type programmatic place predictions. Tap on the search icon on the toolbar and search for a place.</string>
+
+  <!-- FIND CURRENT PLACE -->
+
+  <!-- Text for the find current place submit button. -->
+  <string name="find_current_place_button" translatable="false">Find Current Place</string>
+  <string name="icon_view_content_description" translatable="false">Icon View</string>
+  <string name="fetch_icon_checkbox" translatable="false">Also fetch icon?</string>
+  <string name="fetch_icon_missing_fields_warning" translatable="false">\'Also fetch icon?\' is selected, but ICON_URL Place Field is not.</string>
+  <string name="icon_view_image_content_description" translatable="false">Image view to display a Place Icon Image</string>
+  <string name="icon_with_background" translatable="false">Icon with background:</string>
+  <string name="place_photo" translatable="false">Place photo:</string>
+
+
+  <!-- PLACE DETAILS AND PHOTO -->
+
+  <!-- Place ID for a dining establishment, used as the default for testing in the Place and Photo screen -->
+  <string name="place_id_default" translatable="false">ChIJM3wn3VVYwokRvu2kbqBKUsM</string>
 
   <!-- Hint for the place ID field. -->
   <string name="place_id_field_hint" translatable="false">Enter place ID</string>
@@ -208,33 +219,16 @@
   <string name="fetch_place_and_photo_button" translatable="false">Fetch Place and Photo</string>
 
   <!-- PLACE IS OPEN -->
-  <string name="isOpen_fetchPlaceButtonText" translatable="false">Fetch Place</string>
-  <string name="isOpen_isOpenButtonText" translatable="false">Is Open</string>
+
+  <string name="isOpen_fetchPlaceButtonText" translatable="false">Fetch Place then check IsOpen</string>
+  <string name="isOpen_isOpenButtonText" translatable="false">Request IsOpen by Place ID</string>
   <string name="isOpen_placeIdHint" translatable="false">Enter place ID</string>
   <string name="isOpen_useCustomFieldsText" translatable="false">Manually set Place Fields?</string>
   <string name="isOpen_spinnerDescription" translatable="false">Time Zone</string>
   <string name="isOpen_dateHint" translatable="false">Select isOpen date</string>
   <string name="isOpen_timeHint" translatable="false">Select isOpen time</string>
   <string name="isOpen_useCustomTimeHint" translatable="false">Use custom isOpen time? (must set time zone, date, and time)</string>
-  <string name="isOpen_defaultPlaceId" translatable="false">ChIJ0yqxBq23j4AR53Q9SzIY52A</string>
+  <string name="isOpen_defaultPlaceId" translatable="false">ChIJD3uTd9hx5kcR1IQvGfr8dbk</string>
   <string name="isOpen_resultDescription" translatable="false">Is Place Open?</string>
-  <string name="isOpen_displayRawResults" translatable="false">Display raw results?</string>
-
-  <!-- FIND CURRENT PLACE -->
-
-  <!-- Text for the find current place submit button. -->
-  <string name="find_current_place_button" translatable="false">Find Current Place</string>
-  <string name="icon_view_content_description" translatable="false">Icon View</string>
-  <string name="fetch_icon_checkbox" translatable="false">Also fetch icon?</string>
-  <string name="fetch_icon_missing_fields_warning" translatable="false">\'Also fetch icon?\' is selected, but ICON_URL Place Field is not.</string>
-  <string name="icon_view_image_content_description" translatable="false">Image view to display a Place Icon Image</string>
-  <string name="icon_with_background" translatable="false">Icon with background:</string>
-  <string name="place_photo" translatable="false">Place photo:</string>
-  <!-- Place ID for SFO, used as the default for testing in the Place and Photo screen -->
-  <string name="place_id_SFO" translatable="false">ChIJVVVVVYx3j4ARP-3NGldc8qQ</string>
-
-  <string name="search">Search</string>
-  <string name="search_a_place">Search a Place</string>
-  <string name="programmatic_place_predictions_instructions">This activity demonstrates as-you-type programmatic place predictions. Tap on the search icon on the toolbar and search for a place.</string>
 
 </resources>

--- a/demo-java/app/src/main/res/values/strings.xml
+++ b/demo-java/app/src/main/res/values/strings.xml
@@ -220,14 +220,14 @@
 
   <!-- PLACE IS OPEN -->
 
-  <string name="isOpen_fetchPlaceButtonText" translatable="false">Fetch Place then check IsOpen</string>
-  <string name="isOpen_isOpenButtonText" translatable="false">Request IsOpen by Place ID</string>
-  <string name="isOpen_placeIdHint" translatable="false">Enter place ID</string>
-  <string name="isOpen_useCustomFieldsText" translatable="false">Manually set Place Fields?</string>
-  <string name="isOpen_spinnerDescription" translatable="false">Time Zone</string>
-  <string name="isOpen_dateHint" translatable="false">Select isOpen date</string>
-  <string name="isOpen_timeHint" translatable="false">Select isOpen time</string>
-  <string name="isOpen_useCustomTimeHint" translatable="false">Use custom isOpen time? (must set time zone, date, and time)</string>
-  <string name="isOpen_defaultPlaceId" translatable="false">ChIJD3uTd9hx5kcR1IQvGfr8dbk</string>
+  <string name="isOpen_fetch_place_button_text" translatable="false">Fetch Place then check IsOpen</string>
+  <string name="isOpen_is_open_button_text" translatable="false">Request IsOpen by Place ID</string>
+  <string name="isOpen_place_id_hint" translatable="false">Enter place ID</string>
+  <string name="isOpen_use_custom_fields_text" translatable="false">Manually set Place Fields?</string>
+  <string name="isOpen_spinner_description" translatable="false">Time Zone</string>
+  <string name="isOpen_date_hint" translatable="false">Select isOpen date</string>
+  <string name="isOpen_time_hint" translatable="false">Select isOpen time</string>
+  <string name="isOpen_use_custom_time_hint" translatable="false">Use custom isOpen time? (must set time zone, date, and time)</string>
+  <string name="isOpen_default_place_id" translatable="false">ChIJD3uTd9hx5kcR1IQvGfr8dbk</string>
 
 </resources>

--- a/demo-java/build.gradle
+++ b/demo-java/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:8.0.0'
         classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.1"
     }
 }

--- a/demo-java/build.gradle
+++ b/demo-java/build.gradle
@@ -15,9 +15,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        flatDir {
-            dirs 'libs'
-        }
     }
 }
 

--- a/demo-java/gradle.properties
+++ b/demo-java/gradle.properties
@@ -17,3 +17,6 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/demo-java/gradle/wrapper/gradle-wrapper.properties
+++ b/demo-java/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Mar 28 15:43:44 PDT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/demo-kotlin/app/build.gradle
+++ b/demo-kotlin/app/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation "com.android.databinding:viewbinding:7.3.1"
 
     // Places SDK for Android
-    implementation 'com.google.android.libraries.places:places:3.0.0'
+    implementation 'com.google.android.libraries.places:places:3.1.0'
     implementation 'com.google.maps.android:android-maps-utils:2.4.0'
 }
 repositories {

--- a/demo-kotlin/app/build.gradle
+++ b/demo-kotlin/app/build.gradle
@@ -28,13 +28,13 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.core:core-ktx:1.10.0'
     implementation 'com.android.support:multidex:1.0.3'
-    implementation 'com.google.android.material:material:1.7.0'
+    implementation 'com.google.android.material:material:1.8.0'
     implementation 'com.android.volley:volley:1.2.1'
     implementation "com.github.bumptech.glide:glide:4.13.2"
-    implementation "com.android.databinding:viewbinding:7.3.1"
+    implementation "com.android.databinding:viewbinding:8.0.0"
 
     // Places SDK for Android
     implementation 'com.google.android.libraries.places:places:3.1.0'

--- a/demo-kotlin/app/build.gradle
+++ b/demo-kotlin/app/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
-    id 'kotlin-android-extensions'
+    id 'kotlin-parcelize'
     id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
 }
 
@@ -16,8 +16,8 @@ android {
         versionName "1.0"
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     namespace 'com.example.placesdemo'
 
@@ -27,7 +27,7 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.core:core-ktx:1.10.0'
     implementation 'com.android.support:multidex:1.0.3'

--- a/demo-kotlin/app/src/main/AndroidManifest.xml
+++ b/demo-kotlin/app/src/main/AndroidManifest.xml
@@ -51,7 +51,7 @@
     <activity android:name=".CurrentPlaceActivity" />
     <activity android:name=".PlaceIsOpenActivity" />
     <activity
-      android:name=".programmatic_autocomplete.ProgrammaticAutocompleteToolbarActivity"
+      android:name=".programmatic_autocomplete.ProgrammaticAutocompleteGeocodingActivity"
       android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
 
   </application>

--- a/demo-kotlin/app/src/main/AndroidManifest.xml
+++ b/demo-kotlin/app/src/main/AndroidManifest.xml
@@ -15,7 +15,10 @@
  limitations under the License.
 -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="NotificationPermission">
 
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/demo-kotlin/app/src/main/AndroidManifest.xml
+++ b/demo-kotlin/app/src/main/AndroidManifest.xml
@@ -15,10 +15,7 @@
  limitations under the License.
 -->
 
-<manifest
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:ignore="NotificationPermission">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/demo-kotlin/app/src/main/AndroidManifest.xml
+++ b/demo-kotlin/app/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+  <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
   <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 
   <application

--- a/demo-kotlin/app/src/main/AndroidManifest.xml
+++ b/demo-kotlin/app/src/main/AndroidManifest.xml
@@ -49,6 +49,7 @@
     <activity android:name=".AutocompleteAddressActivity" />
     <activity android:name=".PlaceDetailsAndPhotosActivity" />
     <activity android:name=".CurrentPlaceActivity" />
+    <activity android:name=".PlaceIsOpenActivity" />
     <activity
       android:name=".programmatic_autocomplete.ProgrammaticAutocompleteToolbarActivity"
       android:theme="@style/Theme.AppCompat.Light.NoActionBar" />

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/AutocompleteAddressActivity.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/AutocompleteAddressActivity.kt
@@ -100,7 +100,7 @@ class AutocompleteAddressActivity : AppCompatActivity(R.layout.autocomplete_addr
 
         // Build the autocomplete intent with field, country, and type filters applied
         val intent = Autocomplete.IntentBuilder(AutocompleteActivityMode.OVERLAY, fields)
-            .setCountry("US")
+            .setCountries(listOf("US"))
             //TODO: https://developers.google.com/maps/documentation/places/android-sdk/autocomplete
             .setTypesFilter(listOf(TypeFilter.ADDRESS.toString().lowercase()))
             .build(this)

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/CurrentPlaceActivity.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/CurrentPlaceActivity.kt
@@ -75,13 +75,24 @@ class CurrentPlaceActivity : AppCompatActivity() {
         val placeFields = FieldSelector.allExcept(
             Place.Field.ADDRESS_COMPONENTS,
             Place.Field.CURBSIDE_PICKUP,
+            Place.Field.CURRENT_OPENING_HOURS,
             Place.Field.DELIVERY,
             Place.Field.DINE_IN,
             Place.Field.OPENING_HOURS,
             Place.Field.PHONE_NUMBER,
+            Place.Field.RESERVABLE,
+            Place.Field.SECONDARY_OPENING_HOURS,
+            Place.Field.SERVES_BEER,
+            Place.Field.SERVES_BREAKFAST,
+            Place.Field.SERVES_BRUNCH,
+            Place.Field.SERVES_DINNER,
+            Place.Field.SERVES_LUNCH,
+            Place.Field.SERVES_VEGETARIAN_FOOD,
+            Place.Field.SERVES_WINE,
             Place.Field.TAKEOUT,
             Place.Field.UTC_OFFSET,
-            Place.Field.WEBSITE_URI
+            Place.Field.WEBSITE_URI,
+            Place.Field.WHEELCHAIR_ACCESSIBLE_ENTRANCE
         )
         fieldSelector = FieldSelector(
             binding.useCustomFields,

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/FieldSelector.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/FieldSelector.kt
@@ -84,8 +84,8 @@ class FieldSelector(
     val selectedString: String
         get() {
             val builder = StringBuilder()
-            for (field in selectedFields) {
-                builder.append(field).append("\n")
+            for (eachField in selectedFields) {
+                builder.append(eachField).append("\n")
             }
             return builder.toString()
         }

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/MainActivity.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/MainActivity.kt
@@ -21,7 +21,7 @@ import android.widget.Button
 import android.widget.Toast
 import androidx.annotation.IdRes
 import androidx.appcompat.app.AppCompatActivity
-import com.example.placesdemo.programmatic_autocomplete.ProgrammaticAutocompleteToolbarActivity
+import com.example.placesdemo.programmatic_autocomplete.ProgrammaticAutocompleteGeocodingActivity
 import com.google.android.libraries.places.api.Places
 
 class MainActivity : AppCompatActivity() {
@@ -43,7 +43,7 @@ class MainActivity : AppCompatActivity() {
 
         setLaunchActivityClickListener(R.id.autocomplete_button, PlaceAutocompleteActivity::class.java)
         setLaunchActivityClickListener(R.id.autocomplete_address_button, AutocompleteAddressActivity::class.java)
-        setLaunchActivityClickListener(R.id.programmatic_autocomplete_button, ProgrammaticAutocompleteToolbarActivity::class.java)
+        setLaunchActivityClickListener(R.id.programmatic_autocomplete_button, ProgrammaticAutocompleteGeocodingActivity::class.java)
         setLaunchActivityClickListener(R.id.current_place_button, CurrentPlaceActivity::class.java)
         setLaunchActivityClickListener(R.id.place_and_photo_button, PlaceDetailsAndPhotosActivity::class.java)
         setLaunchActivityClickListener(R.id.is_open_button, PlaceIsOpenActivity::class.java)

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/MainActivity.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/MainActivity.kt
@@ -41,11 +41,12 @@ class MainActivity : AppCompatActivity() {
             Places.initialize(applicationContext, apiKey)
         }
 
-        setLaunchActivityClickListener(R.id.programmatic_autocomplete_button, ProgrammaticAutocompleteToolbarActivity::class.java)
-        setLaunchActivityClickListener(R.id.autocomplete_address_button, AutocompleteAddressActivity::class.java)
         setLaunchActivityClickListener(R.id.autocomplete_button, PlaceAutocompleteActivity::class.java)
-        setLaunchActivityClickListener(R.id.place_and_photo_button, PlaceDetailsAndPhotosActivity::class.java)
+        setLaunchActivityClickListener(R.id.autocomplete_address_button, AutocompleteAddressActivity::class.java)
+        setLaunchActivityClickListener(R.id.programmatic_autocomplete_button, ProgrammaticAutocompleteToolbarActivity::class.java)
         setLaunchActivityClickListener(R.id.current_place_button, CurrentPlaceActivity::class.java)
+        setLaunchActivityClickListener(R.id.place_and_photo_button, PlaceDetailsAndPhotosActivity::class.java)
+        setLaunchActivityClickListener(R.id.is_open_button, PlaceIsOpenActivity::class.java)
     }
 
     private fun setLaunchActivityClickListener(@IdRes onClickResId: Int, activityClassToLaunch: Class<out AppCompatActivity>) {

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/PlaceAutocompleteActivity.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/PlaceAutocompleteActivity.kt
@@ -129,7 +129,7 @@ class PlaceAutocompleteActivity : AppCompatActivity() {
     /**
      * Launches Autocomplete activity and handles result
      */
-    var autocompleteLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+    private var autocompleteLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
         result ->
         when (result.resultCode) {
             AutocompleteActivity.RESULT_OK -> {
@@ -286,9 +286,5 @@ class PlaceAutocompleteActivity : AppCompatActivity() {
             .setTitle(R.string.error_alert_title)
             .setMessage(messageResId)
             .show()
-    }
-
-    companion object {
-        private const val AUTOCOMPLETE_REQUEST_CODE = 23487
     }
 }

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/PlaceAutocompleteActivity.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/PlaceAutocompleteActivity.kt
@@ -19,7 +19,9 @@ import android.content.Intent
 import android.os.Bundle
 import android.text.TextUtils
 import android.view.View
-import android.widget.*
+import android.widget.CheckBox
+import android.widget.TextView
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.IdRes
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
@@ -41,7 +43,6 @@ import com.google.android.libraries.places.widget.AutocompleteActivity
 import com.google.android.libraries.places.widget.AutocompleteSupportFragment
 import com.google.android.libraries.places.widget.listener.PlaceSelectionListener
 import com.google.android.libraries.places.widget.model.AutocompleteActivityMode
-import java.util.*
 
 /**
  * Activity to demonstrate Place Autocomplete (activity widget intent, fragment widget, and
@@ -126,31 +127,27 @@ class PlaceAutocompleteActivity : AppCompatActivity() {
         }
 
     /**
-     * Called when AutocompleteActivity finishes
+     * Launches Autocomplete activity and handles result
      */
-    @Deprecated("Deprecated in Java")
-    override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
-        if (requestCode == AUTOCOMPLETE_REQUEST_CODE && intent != null) {
-            when (resultCode) {
-                AutocompleteActivity.RESULT_OK -> {
-                    val place = Autocomplete.getPlaceFromIntent(intent)
+    var autocompleteLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+        result ->
+        when (result.resultCode) {
+            AutocompleteActivity.RESULT_OK -> {
+                val data: Intent? = result.data
+                if (data != null) {
+                    val place = Autocomplete.getPlaceFromIntent(data)
                     binding.response.text =
                         StringUtil.stringifyAutocompleteWidget(place, isDisplayRawResultsChecked)
                 }
-                AutocompleteActivity.RESULT_ERROR -> {
-                    val status = Autocomplete.getStatusFromIntent(intent)
-                    binding.response.text = status.statusMessage
-                }
-                AutocompleteActivity.RESULT_CANCELED -> {
-                    // The user canceled the operation.
-                }
+            }
+            AutocompleteActivity.RESULT_ERROR -> {
+                val status = Autocomplete.getStatusFromIntent(intent)
+                binding.response.text = status.statusMessage
+            }
+            AutocompleteActivity.RESULT_CANCELED -> {
+                // The user canceled the operation.
             }
         }
-
-        // Required because this class extends AppCompatActivity which extends FragmentActivity
-        // which implements this method to pass onActivityResult calls to child fragments
-        // (eg AutocompleteFragment).
-        super.onActivityResult(requestCode, resultCode, intent)
     }
 
     private fun startAutocompleteActivity() {
@@ -162,7 +159,7 @@ class PlaceAutocompleteActivity : AppCompatActivity() {
             .setLocationRestriction(locationRestriction)
             .setTypesFilter(getTypesFilter())
             .build(this)
-        startActivityForResult(autocompleteIntent, AUTOCOMPLETE_REQUEST_CODE)
+        autocompleteLauncher.launch(autocompleteIntent)
     }
 
     private fun findAutocompletePredictions() {

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/PlaceIsOpenActivity.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/PlaceIsOpenActivity.kt
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.placesdemo
+
+import android.annotation.SuppressLint
+import android.app.DatePickerDialog
+import android.app.TimePickerDialog
+import android.content.Context
+import android.os.Bundle
+import android.view.View
+import android.view.inputmethod.InputMethodManager
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import android.widget.EditText
+import androidx.appcompat.app.AppCompatActivity
+import com.example.placesdemo.StringUtil.stringify
+import com.example.placesdemo.databinding.PlaceIsOpenActivityBinding
+import com.google.android.gms.tasks.Task
+import com.google.android.libraries.places.api.Places
+import com.google.android.libraries.places.api.model.Place
+import com.google.android.libraries.places.api.net.FetchPlaceRequest
+import com.google.android.libraries.places.api.net.IsOpenRequest
+import com.google.android.libraries.places.api.net.IsOpenResponse
+import com.google.android.libraries.places.api.net.PlacesClient
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Locale
+import java.util.TimeZone.*
+
+/**
+ * Activity to demonstrate [PlacesClient.isOpen].
+ */
+class PlaceIsOpenActivity : AppCompatActivity() {
+    private val defaultTimeZone = getDefault()
+    private val defaultTimeZoneID: String = defaultTimeZone.id
+
+    private var isOpenCalendar: Calendar = Calendar.getInstance()
+
+    private lateinit var placesClient: PlacesClient
+    private lateinit var fieldSelector: FieldSelector
+    private lateinit var binding: PlaceIsOpenActivityBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        binding = PlaceIsOpenActivityBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        // Retrieve a PlacesClient (previously initialized - see MainActivity)
+        placesClient = Places.createClient( /* context = */this)
+
+        fieldSelector = FieldSelector(
+            binding.checkBoxUseCustomFields,
+            binding.textViewCustomFieldsList,
+            savedInstanceState
+        )
+
+        binding.buttonFetchPlace.setOnClickListener { fetchPlace() }
+        binding.buttonIsOpen.setOnClickListener { isOpenByPlaceId() }
+
+        isOpenCalendar = Calendar.getInstance(defaultTimeZone)
+
+        // UI initialization
+        setLoading(false)
+        initializeSpinnerAndAddListener()
+        addIsOpenDateSelectionListener()
+        addIsOpenTimeSelectionListener()
+        updateIsOpenDate()
+        updateIsOpenTime()
+    }
+
+    override fun onSaveInstanceState(bundle: Bundle) {
+        super.onSaveInstanceState(bundle)
+        fieldSelector.onSaveInstanceState(bundle)
+    }
+
+    /**
+     * Get details about the Place ID listed in the input field, then check if the Place is open.
+     */
+    private fun fetchPlace() {
+        clearViews()
+        dismissKeyboard(binding.editTextPlaceId)
+        setLoading(true)
+
+        val placeFields = this.placeFields
+        val request = FetchPlaceRequest.newInstance(placeId, placeFields)
+        val placeTask = placesClient.fetchPlace(request)
+        placeTask.addOnSuccessListener { response ->
+            isOpenByPlaceObject(response.place)
+        }
+        placeTask.addOnFailureListener { exception ->
+            exception.printStackTrace()
+            binding.textViewResponse.text = exception.message
+        }
+        placeTask.addOnCompleteListener { setLoading(false) }
+    }
+
+    /**
+     * Check if the place is open at the time specified in the input fields.
+     * Requires a Place object that includes Place.Field.ID
+     */
+    @SuppressLint("SetTextI18n")
+    private fun isOpenByPlaceObject(place: Place?) {
+        clearViews()
+        dismissKeyboard(binding.editTextPlaceId)
+        setLoading(true)
+
+        val request: IsOpenRequest = try {
+            IsOpenRequest.newInstance(place, isOpenCalendar.timeInMillis)
+        } catch (e: IllegalArgumentException) {
+            e.printStackTrace()
+            binding.textViewResponse.text = e.message
+            setLoading(false)
+            return
+        }
+        val placeTask: Task<IsOpenResponse> = placesClient.isOpen(request)
+        placeTask.addOnSuccessListener { response ->
+            binding.textViewResponse.text =
+                "Is place open? " + response.isOpen + "\nExtra place details: \n" + place?.let {
+                    stringify(
+                        it
+                    )
+                }
+        }
+        placeTask.addOnFailureListener { exception ->
+            exception.printStackTrace()
+            binding.textViewResponse.text = exception.message
+        }
+        placeTask.addOnCompleteListener { setLoading(false) }
+    }
+
+    /**
+     * Check if the place is open at the time specified in the input fields.
+     * Use the Place ID in the input field for the isOpenRequest.
+     */
+    @SuppressLint("SetTextI18n")
+    private fun isOpenByPlaceId() {
+        clearViews()
+        dismissKeyboard(binding.editTextPlaceId)
+        setLoading(true)
+
+        val request: IsOpenRequest = try {
+            IsOpenRequest.newInstance(placeId, isOpenCalendar.timeInMillis)
+        } catch (e: IllegalArgumentException) {
+            e.printStackTrace()
+            binding.textViewResponse.text = e.message
+            setLoading(false)
+            return
+        }
+        val placeTask: Task<IsOpenResponse> = placesClient.isOpen(request)
+        placeTask.addOnSuccessListener { response ->
+            binding.textViewResponse.text = "Is place open? " + response.isOpen
+        }
+        placeTask.addOnFailureListener { exception ->
+            exception.printStackTrace()
+            binding.textViewResponse.text = exception.message
+        }
+        placeTask.addOnCompleteListener { setLoading(false) }
+    }
+
+    //////////////////////////
+    // Helper methods below //
+    //////////////////////////
+    private fun dismissKeyboard(focusedEditText: EditText) {
+        val imm: InputMethodManager =
+            getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        imm.hideSoftInputFromWindow(focusedEditText.windowToken, 0)
+    }
+
+    private val placeId: String
+        get() = binding.editTextPlaceId.text.toString()
+
+    /**
+     * Fetch the fields necessary for an isOpen request, unless user has checked the box to
+     * select a custom list of fields. Also fetches name and address for display text.
+     */
+    private val placeFields: List<Place.Field>
+        get() = if (isUseCustomFieldsChecked) {
+            fieldSelector.selectedFields
+        } else {
+            listOf(
+                Place.Field.ADDRESS,
+                Place.Field.BUSINESS_STATUS,
+                Place.Field.CURRENT_OPENING_HOURS,
+                Place.Field.ID,
+                Place.Field.NAME,
+                Place.Field.OPENING_HOURS,
+                Place.Field.UTC_OFFSET
+            )
+        }
+
+    private fun setLoading(loading: Boolean) {
+        if (loading) {
+            binding.progressBarLoading.visibility = View.VISIBLE
+        } else {
+            binding.progressBarLoading.visibility = View.INVISIBLE
+        }
+    }
+
+    private fun clearViews() {
+        binding.textViewResponse.text = null
+    }
+
+    private fun initializeSpinnerAndAddListener() {
+        val adapter: ArrayAdapter<String> =
+            ArrayAdapter(this, android.R.layout.simple_spinner_item, getAvailableIDs())
+        binding.spinnerTimeZones.adapter = adapter
+        binding.spinnerTimeZones.setSelection(adapter.getPosition(defaultTimeZoneID))
+        binding.spinnerTimeZones.onItemSelectedListener =
+            object : AdapterView.OnItemSelectedListener {
+                override fun onItemSelected(
+                    parent: AdapterView<*>?,
+                    view: View?,
+                    position: Int,
+                    id: Long
+                ) {
+                    val timeZone: String = parent!!.getItemAtPosition(position).toString()
+                    isOpenCalendar.timeZone = getTimeZone(timeZone)
+                    updateIsOpenDate()
+                    updateIsOpenTime()
+                }
+
+                override fun onNothingSelected(parent: AdapterView<*>?) {
+                }
+            }
+    }
+
+    private fun addIsOpenDateSelectionListener() {
+        val listener: DatePickerDialog.OnDateSetListener =
+            DatePickerDialog.OnDateSetListener { _, year, month, day ->
+                isOpenCalendar.set(Calendar.YEAR, year)
+                isOpenCalendar.set(Calendar.MONTH, month)
+                isOpenCalendar.set(Calendar.DAY_OF_MONTH, day)
+                updateIsOpenDate()
+            }
+        binding.editTextIsOpenDate.setOnClickListener {
+            DatePickerDialog(
+                this@PlaceIsOpenActivity,
+                listener,
+                isOpenCalendar.get(Calendar.YEAR),
+                isOpenCalendar.get(Calendar.MONTH),
+                isOpenCalendar.get(Calendar.DAY_OF_MONTH)
+            )
+                .show()
+        }
+    }
+
+    private fun updateIsOpenDate() {
+        val dateFormat = SimpleDateFormat("MM/dd/yy", Locale.US)
+        binding.editTextIsOpenDate.setText(dateFormat.format(isOpenCalendar.timeInMillis))
+    }
+
+    private fun addIsOpenTimeSelectionListener() {
+        val listener: TimePickerDialog.OnTimeSetListener =
+            TimePickerDialog.OnTimeSetListener { _, hourOfDay, minute ->
+                isOpenCalendar.set(Calendar.HOUR_OF_DAY, hourOfDay)
+                isOpenCalendar.set(Calendar.MINUTE, minute)
+                updateIsOpenTime()
+            }
+        binding.editTextIsOpenTime.setOnClickListener {
+            TimePickerDialog(
+                this@PlaceIsOpenActivity,
+                listener,
+                isOpenCalendar.get(Calendar.HOUR_OF_DAY),
+                isOpenCalendar.get(Calendar.MINUTE),
+                true
+            )
+                .show()
+        }
+    }
+
+    private fun updateIsOpenTime() {
+        val formattedHour: String =
+            String.format(Locale.getDefault(), "%02d", isOpenCalendar.get(Calendar.HOUR_OF_DAY))
+        val formattedMinutes: String =
+            String.format(Locale.getDefault(), "%02d", isOpenCalendar.get(Calendar.MINUTE))
+        binding.editTextIsOpenTime.setText(
+            String.format(Locale.getDefault(), "%s:%s", formattedHour, formattedMinutes)
+        )
+    }
+
+    private val isUseCustomFieldsChecked: Boolean
+        get() = binding.checkBoxUseCustomFields.isChecked
+}

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/PlaceIsOpenActivity.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/PlaceIsOpenActivity.kt
@@ -113,7 +113,7 @@ class PlaceIsOpenActivity : AppCompatActivity() {
      * Requires a Place object that includes Place.Field.ID
      */
     @SuppressLint("SetTextI18n")
-    private fun isOpenByPlaceObject(place: Place?) {
+    private fun isOpenByPlaceObject(place: Place) {
         clearViews()
         dismissKeyboard(binding.editTextPlaceId)
         setLoading(true)
@@ -129,13 +129,10 @@ class PlaceIsOpenActivity : AppCompatActivity() {
         val placeTask: Task<IsOpenResponse> = placesClient.isOpen(request)
         placeTask.addOnSuccessListener { response ->
             binding.textViewResponse.text =
-                "Is place open? " + response.isOpen + "\nExtra place details: \n" + place?.let {
-                    stringify(
-                        it
-                    )
-                }
+                "Is place open? " + response.isOpen + "\nExtra place details: \n" + stringify(place)
         }
-        placeTask.addOnFailureListener { exception ->
+        placeTask.addOnFailureListener {
+                exception ->
             exception.printStackTrace()
             binding.textViewResponse.text = exception.message
         }
@@ -172,8 +169,8 @@ class PlaceIsOpenActivity : AppCompatActivity() {
     }
 
     //////////////////////////
-    // Helper methods below //
-    //////////////////////////
+// Helper methods below //
+//////////////////////////
     private fun dismissKeyboard(focusedEditText: EditText) {
         val imm: InputMethodManager =
             getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/PlaceIsOpenActivity.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/PlaceIsOpenActivity.kt
@@ -129,7 +129,7 @@ class PlaceIsOpenActivity : AppCompatActivity() {
         val placeTask: Task<IsOpenResponse> = placesClient.isOpen(request)
         placeTask.addOnSuccessListener { response ->
             binding.textViewResponse.text =
-                "Is place open? " + response.isOpen + "\nExtra place details: \n" + stringify(place)
+                "Is place open? ${response.isOpen}\nExtra place details: \n${stringify(place)}"
         }
         placeTask.addOnFailureListener {
                 exception ->

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/StringUtil.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/StringUtil.kt
@@ -70,7 +70,7 @@ object StringUtil {
 
     fun countriesStringToArrayList(countriesString: String): List<String> {
         // Allow these delimiters: , ; | / \
-        return Arrays.asList(*countriesString
+        return listOf(*countriesString
             .replace("\\s".toRegex(), "|")
             .split("[,;|/\\\\]").dropLastWhile { it.isEmpty() }.toTypedArray())
     }
@@ -125,12 +125,7 @@ object StringUtil {
     }
 
     fun stringify(place: Place): String {
-        return (place.name
-            + " ("
-            + place.address
-            + ")"
-            + " is open now? "
-            + place.isOpen(System.currentTimeMillis()))
+        return "${place.name?.plus(" (") ?: ""}${place.address?.plus(")") ?: ""}"
     }
 
     fun stringify(bitmap: Bitmap): String {

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/programmatic_autocomplete/ProgrammaticAutocompleteGeocodingActivity.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/programmatic_autocomplete/ProgrammaticAutocompleteGeocodingActivity.kt
@@ -174,7 +174,7 @@ class ProgrammaticAutocompleteGeocodingActivity : AppCompatActivity() {
             }.addOnFailureListener { exception: Exception? ->
                 progressBar.isIndeterminate = false
                 if (exception is ApiException) {
-                    Log.e(TAG, "Place not found: " + exception.message)
+                    Log.e(TAG, "Place not found: ${exception.message}")
                 }
             }
     }
@@ -220,7 +220,7 @@ class ProgrammaticAutocompleteGeocodingActivity : AppCompatActivity() {
         queue.add(request)
     }
 
-    private fun displayDialog(place: AutocompletePrediction, result: GeocodingResult): Unit {
+    private fun displayDialog(place: AutocompletePrediction, result: GeocodingResult) {
         AlertDialog.Builder(this)
             .setTitle(place.getPrimaryText(null))
             .setMessage("Geocoding result:\n" + result.geometry?.location)

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/programmatic_autocomplete/ProgrammaticAutocompleteGeocodingActivity.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/programmatic_autocomplete/ProgrammaticAutocompleteGeocodingActivity.kt
@@ -42,6 +42,7 @@ import com.google.android.libraries.places.api.model.AutocompletePrediction
 import com.google.android.libraries.places.api.model.AutocompleteSessionToken
 import com.google.android.libraries.places.api.model.LocationBias
 import com.google.android.libraries.places.api.model.Place
+import com.google.android.libraries.places.api.model.PlaceTypes
 import com.google.android.libraries.places.api.model.RectangularBounds
 import com.google.android.libraries.places.api.net.FetchPlaceRequest
 import com.google.android.libraries.places.api.net.FetchPlaceResponse
@@ -133,6 +134,7 @@ class ProgrammaticAutocompleteGeocodingActivity : AppCompatActivity() {
         // Get just the location of the place using the Geocoding API
         adapter.onPlaceClickListener = { geocodePlaceAndDisplay(it) }
         // Alternative: Get more details about the place using Place Details
+        // See https://goo.gle/paaln for help choosing between Geocoding and Place Details
         // adapter.onPlaceClickListener = { fetchPlaceAndDisplay(it) }
     }
 
@@ -156,8 +158,7 @@ class ProgrammaticAutocompleteGeocodingActivity : AppCompatActivity() {
         val newRequest = FindAutocompletePredictionsRequest.builder()
             .setLocationBias(bias)
             .setCountries("IN")
-            .setTypesFilter(listOf("establishment")) // https://issuetracker.google.com/issues/261035620
-            // .setTypesFilter(listOf(TypeFilter.ESTABLISHMENT.toString()))
+            .setTypesFilter(listOf(PlaceTypes.ESTABLISHMENT))
             // Session Token only used to link related Place Details call. See https://goo.gle/paaln
             .setSessionToken(sessionToken)
             .setQuery(query)

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/programmatic_autocomplete/ProgrammaticAutocompleteGeocodingActivity.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/programmatic_autocomplete/ProgrammaticAutocompleteGeocodingActivity.kt
@@ -16,6 +16,7 @@ package com.example.placesdemo.programmatic_autocomplete
 
 import android.os.Bundle
 import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
@@ -32,7 +33,6 @@ import com.android.volley.RequestQueue
 import com.android.volley.toolbox.JsonObjectRequest
 import com.android.volley.toolbox.Volley
 import com.example.placesdemo.BuildConfig
-import com.example.placesdemo.MainActivity
 import com.example.placesdemo.R
 import com.example.placesdemo.model.GeocodingResult
 import com.google.android.gms.common.api.ApiException
@@ -41,8 +41,10 @@ import com.google.android.libraries.places.api.Places
 import com.google.android.libraries.places.api.model.AutocompletePrediction
 import com.google.android.libraries.places.api.model.AutocompleteSessionToken
 import com.google.android.libraries.places.api.model.LocationBias
+import com.google.android.libraries.places.api.model.Place
 import com.google.android.libraries.places.api.model.RectangularBounds
-import com.google.android.libraries.places.api.model.TypeFilter
+import com.google.android.libraries.places.api.net.FetchPlaceRequest
+import com.google.android.libraries.places.api.net.FetchPlaceResponse
 import com.google.android.libraries.places.api.net.FindAutocompletePredictionsRequest
 import com.google.android.libraries.places.api.net.PlacesClient
 import com.google.gson.GsonBuilder
@@ -52,13 +54,13 @@ import org.json.JSONException
 /**
  * An Activity that demonstrates programmatic as-you-type place predictions. The parameters of the
  * request are currently hard coded in this Activity, to modify these parameters (e.g. location
- * bias, place types, etc.), see [ProgrammaticAutocompleteToolbarActivity.getPlacePredictions]
+ * bias, place types, etc.), see [ProgrammaticAutocompleteGeocodingActivity.getPlacePredictions]
  *
  * @see https://developers.google.com/places/android-sdk/autocomplete#get_place_predictions_programmatically
  */
-class ProgrammaticAutocompleteToolbarActivity : AppCompatActivity() {
+class ProgrammaticAutocompleteGeocodingActivity : AppCompatActivity() {
 
-    private val handler = Handler()
+    private val handler = Handler(Looper.getMainLooper())
     private val adapter = PlacePredictionAdapter()
     private val gson = GsonBuilder().registerTypeAdapter(LatLng::class.java, LatLngAdapter()).create()
 
@@ -128,7 +130,10 @@ class ProgrammaticAutocompleteToolbarActivity : AppCompatActivity() {
         recyclerView.layoutManager = layoutManager
         recyclerView.adapter = adapter
         recyclerView.addItemDecoration(DividerItemDecoration(this, layoutManager.orientation))
+        // Get just the location of the place using the Geocoding API
         adapter.onPlaceClickListener = { geocodePlaceAndDisplay(it) }
+        // Alternative: Get more details about the place using Place Details
+        // adapter.onPlaceClickListener = { fetchPlaceAndDisplay(it) }
     }
 
     /**
@@ -148,32 +153,34 @@ class ProgrammaticAutocompleteToolbarActivity : AppCompatActivity() {
         )
 
         // Create a new programmatic Place Autocomplete request in Places SDK for Android
-        val newRequest = FindAutocompletePredictionsRequest
-            .builder()
-            .setSessionToken(sessionToken)
+        val newRequest = FindAutocompletePredictionsRequest.builder()
             .setLocationBias(bias)
-            .setTypeFilter(TypeFilter.ESTABLISHMENT)
-            .setQuery(query)
             .setCountries("IN")
+            .setTypesFilter(listOf("establishment")) // https://issuetracker.google.com/issues/261035620
+            // .setTypesFilter(listOf(TypeFilter.ESTABLISHMENT.toString()))
+            // Session Token only used to link related Place Details call. See https://goo.gle/paaln
+            .setSessionToken(sessionToken)
+            .setQuery(query)
             .build()
 
         // Perform autocomplete predictions request
-        placesClient.findAutocompletePredictions(newRequest).addOnSuccessListener { response ->
-            val predictions = response.autocompletePredictions
-            adapter.setPredictions(predictions)
-            progressBar.isIndeterminate = false
-            viewAnimator.displayedChild = if (predictions.isEmpty()) 0 else 1
-        }.addOnFailureListener { exception: Exception? ->
-            progressBar.isIndeterminate = false
-            if (exception is ApiException) {
-                Log.e(TAG, "Place not found: " + exception.statusCode)
+        placesClient.findAutocompletePredictions(newRequest)
+            .addOnSuccessListener { response ->
+                val predictions = response.autocompletePredictions
+                adapter.setPredictions(predictions)
+                progressBar.isIndeterminate = false
+                viewAnimator.displayedChild = if (predictions.isEmpty()) 0 else 1
+            }.addOnFailureListener { exception: Exception? ->
+                progressBar.isIndeterminate = false
+                if (exception is ApiException) {
+                    Log.e(TAG, "Place not found: " + exception.message)
+                }
             }
-        }
     }
-
 
     /**
      * Performs a Geocoding API request and displays the result in a dialog.
+     * Be sure to enable Geocoding API in your project and API key restrictions.
      *
      * @see https://developers.google.com/places/android-sdk/autocomplete#get_place_predictions_programmatically
      */
@@ -186,6 +193,11 @@ class ProgrammaticAutocompleteToolbarActivity : AppCompatActivity() {
         // Use the HTTP request URL for Geocoding API to get geographic coordinates for the place
         val request = JsonObjectRequest(Request.Method.GET, requestURL, null, { response ->
             try {
+                val status: String = response.getString("status")
+                if (status != "OK") {
+                    Log.e(TAG, "$status " + response.getString("error_message"))
+                }
+
                 // Inspect the value of "results" and make sure it's not empty
                 val results: JSONArray = response.getJSONArray("results")
                 if (results.length() == 0) {
@@ -215,9 +227,37 @@ class ProgrammaticAutocompleteToolbarActivity : AppCompatActivity() {
             .show()
     }
 
+    /**
+     * Performs a Place Details request and displays the result in a dialog.
+     *
+     * @see https://developers.google.com/maps/documentation/places/android-sdk/place-details#maps_places_get_place_by_id-kotlin
+     */
+    private fun fetchPlaceAndDisplay(placePrediction: AutocompletePrediction) {
+        // Specify the fields to return.
+        val placeFields = listOf(Place.Field.ID, Place.Field.NAME, Place.Field.ADDRESS)
+
+        // Construct a request object, passing the place ID and fields array.
+        val request = FetchPlaceRequest.newInstance(placePrediction.placeId, placeFields)
+
+        placesClient.fetchPlace(request)
+            .addOnSuccessListener { response: FetchPlaceResponse ->
+                val place = response.place
+                AlertDialog.Builder(this)
+                    .setTitle(place.name)
+                    .setMessage("located at:\n" + place.address)
+                    .setPositiveButton(android.R.string.ok, null)
+                    .show()
+                Log.i(TAG, "Place found: ${place.name}")
+            }.addOnFailureListener { exception: Exception ->
+                if (exception is ApiException) {
+                    Log.e(TAG, "Place not found: ${exception.message} ${exception.statusCode}")
+                }
+            }
+    }
+
 
     companion object {
-        private val TAG = ProgrammaticAutocompleteToolbarActivity::class.java.simpleName
+        private val TAG = ProgrammaticAutocompleteGeocodingActivity::class.java.simpleName
     }
 }
 

--- a/demo-kotlin/app/src/main/res/layout/activity_main.xml
+++ b/demo-kotlin/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
  Copyright 2020 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,8 +14,7 @@
  limitations under the License.
 -->
 
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -24,47 +22,47 @@
     android:orientation="vertical"
     tools:context=".MainActivity">
 
-  <Button
-      android:id="@+id/autocomplete_button"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_margin="@dimen/spacing_small"
-      android:text="@string/autocomplete_button"/>
+    <Button
+        android:id="@+id/autocomplete_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/spacing_small"
+        android:text="@string/autocomplete_button" />
 
-  <Button
-      android:id="@+id/autocomplete_address_button"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_margin="@dimen/spacing_small"
-      android:text="@string/autocomplete_address_button"/>
+    <Button
+        android:id="@+id/autocomplete_address_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/spacing_small"
+        android:text="@string/autocomplete_address_button" />
 
-  <Button
-    android:id="@+id/programmatic_autocomplete_button"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_margin="@dimen/spacing_small"
-    android:text="@string/programmatic_autocomplete_geocoding"/>
+    <Button
+        android:id="@+id/programmatic_autocomplete_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/spacing_small"
+        android:text="@string/programmatic_autocomplete_geocoding" />
 
-  <Button
-      android:id="@+id/current_place_button"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_margin="@dimen/spacing_small"
-      android:text="@string/current_place_button"/>
+    <Button
+        android:id="@+id/current_place_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/spacing_small"
+        android:text="@string/current_place_button" />
 
-  <Button
-      android:id="@+id/place_and_photo_button"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_margin="@dimen/spacing_small"
-      android:text="@string/place_and_photo_button"/>
+    <Button
+        android:id="@+id/place_and_photo_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/spacing_small"
+        android:text="@string/place_and_photo_button" />
 
-  <Button
-      android:id="@+id/is_open_button"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_margin="@dimen/spacing_small"
-      android:text="@string/main_isOpenButtonText"/>
+    <Button
+        android:id="@+id/is_open_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/spacing_small"
+        android:text="@string/main_isOpenButtonText" />
 
 </LinearLayout>
 

--- a/demo-kotlin/app/src/main/res/layout/activity_main.xml
+++ b/demo-kotlin/app/src/main/res/layout/activity_main.xml
@@ -25,39 +25,46 @@
     tools:context=".MainActivity">
 
   <Button
-    android:id="@+id/programmatic_autocomplete_button"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_margin="@dimen/spacing_small"
-    android:text="@string/programmatic_autocomplete_geocoding"/>
-
-  <Button
-      android:id="@+id/autocomplete_address_button"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_margin="@dimen/spacing_small"
-      android:text="@string/autocomplete_address_button"/>
-
-  <Button
       android:id="@+id/autocomplete_button"
-      android:layout_width="wrap_content"
+      android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_margin="@dimen/spacing_small"
       android:text="@string/autocomplete_button"/>
 
   <Button
+      android:id="@+id/autocomplete_address_button"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_margin="@dimen/spacing_small"
+      android:text="@string/autocomplete_address_button"/>
+
+  <Button
+    android:id="@+id/programmatic_autocomplete_button"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="@dimen/spacing_small"
+    android:text="@string/programmatic_autocomplete_geocoding"/>
+
+  <Button
+      android:id="@+id/current_place_button"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_margin="@dimen/spacing_small"
+      android:text="@string/current_place_button"/>
+
+  <Button
       android:id="@+id/place_and_photo_button"
-      android:layout_width="wrap_content"
+      android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_margin="@dimen/spacing_small"
       android:text="@string/place_and_photo_button"/>
 
   <Button
-      android:id="@+id/current_place_button"
-      android:layout_width="wrap_content"
+      android:id="@+id/is_open_button"
+      android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_margin="@dimen/spacing_small"
-      android:text="@string/current_place_button"/>
+      android:text="@string/main_isOpenButtonText"/>
 
 </LinearLayout>
 

--- a/demo-kotlin/app/src/main/res/layout/activity_programmatic_autocomplete.xml
+++ b/demo-kotlin/app/src/main/res/layout/activity_programmatic_autocomplete.xml
@@ -20,7 +20,7 @@
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:orientation="vertical"
-  tools:context=".programmatic_autocomplete.ProgrammaticAutocompleteToolbarActivity">
+  tools:context=".programmatic_autocomplete.ProgrammaticAutocompleteGeocodingActivity">
 
   <com.google.android.material.appbar.AppBarLayout
     android:layout_width="match_parent"

--- a/demo-kotlin/app/src/main/res/layout/current_place_activity.xml
+++ b/demo-kotlin/app/src/main/res/layout/current_place_activity.xml
@@ -66,7 +66,6 @@
         style="?android:attr/progressBarStyleSmall"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_centerHorizontal="true"
         android:visibility="invisible"/>
 
     <TextView

--- a/demo-kotlin/app/src/main/res/layout/place_autocomplete_activity.xml
+++ b/demo-kotlin/app/src/main/res/layout/place_autocomplete_activity.xml
@@ -58,6 +58,7 @@
           android:id="@+id/autocomplete_location_bias_south_west"
           android:layout_width="0dp"
           android:layout_height="wrap_content"
+          android:minHeight="48dp"
           android:layout_weight="1"
           android:hint="@string/autocomplete_location_south_west_hint"
           android:autofillHints=""
@@ -89,6 +90,7 @@
           android:id="@+id/autocomplete_location_restriction_south_west"
           android:layout_width="0dp"
           android:layout_height="wrap_content"
+          android:minHeight="48dp"
           android:layout_weight="1"
           android:hint="@string/autocomplete_location_south_west_hint"
           android:autofillHints=""
@@ -143,6 +145,7 @@
           android:id="@+id/autocomplete_use_types_filter_checkbox"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
+          android:minHeight="48dp"
           android:checked="false"
           android:text="@string/autocomplete_use_types_filter"/>
 
@@ -157,29 +160,12 @@
 
     </LinearLayout>
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-      <CheckBox
-          android:id="@+id/autocomplete_use_type_filter"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:checked="false"
-          android:text="@string/autocomplete_use_type_filter"/>
-
-      <Spinner
-          android:id="@+id/autocomplete_type_filter"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"/>
-    </LinearLayout>
-
     <!-- Autocomplete predictions only -->
     <CheckBox
         android:id="@+id/autocomplete_use_session_token"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:minHeight="48dp"
         android:checked="false"
         android:text="@string/autocomplete_use_session_token"/>
 
@@ -188,6 +174,7 @@
         android:id="@+id/autocomplete_activity_overlay_mode"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:minHeight="48dp"
         android:checked="false"
         android:text="@string/autocomplete_activity_overlay_mode"/>
 
@@ -198,9 +185,9 @@
 
       <CheckBox
           android:id="@+id/use_custom_fields"
-          android:layout_width="0dp"
+          android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_weight="1"
+          android:minHeight="48dp"
           android:text="@string/use_custom_fields"/>
 
       <TextView
@@ -230,11 +217,12 @@
         android:id="@+id/autocomplete_support_fragment_text_label"
         android:text="@string/autocomplete_support_fragment_text_label"/>
 
-    <fragment
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/autocomplete_support_fragment"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:name="com.google.android.libraries.places.widget.AutocompleteSupportFragment"/>
+        android:name="com.google.android.libraries.places.widget.AutocompleteSupportFragment"
+        tools:layout="@layout/places_autocomplete_fragment" />
 
     <Button
         android:id="@+id/autocomplete_support_fragment_update_button"
@@ -255,7 +243,6 @@
         style="?android:attr/progressBarStyleSmall"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_centerHorizontal="true"
         android:visibility="invisible"/>
 
     <TextView
@@ -266,4 +253,3 @@
 
   </LinearLayout>
 </ScrollView>
-

--- a/demo-kotlin/app/src/main/res/layout/place_details_and_photos_activity.xml
+++ b/demo-kotlin/app/src/main/res/layout/place_details_and_photos_activity.xml
@@ -38,7 +38,7 @@
         android:autofillHints=""
         android:imeOptions="actionGo"
         android:inputType="text"
-        android:text="@string/place_id_SFO"/>
+        android:text="@string/place_id_default"/>
 
     <CheckBox
         android:id="@+id/fetch_photo_checkbox"

--- a/demo-kotlin/app/src/main/res/layout/place_details_and_photos_activity.xml
+++ b/demo-kotlin/app/src/main/res/layout/place_details_and_photos_activity.xml
@@ -169,7 +169,6 @@
           style="?android:attr/progressBarStyleSmall"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_centerHorizontal="true"
           android:visibility="invisible"/>
 
     </LinearLayout>

--- a/demo-kotlin/app/src/main/res/layout/place_is_open_activity.xml
+++ b/demo-kotlin/app/src/main/res/layout/place_is_open_activity.xml
@@ -33,11 +33,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:autofillHints=""
-            android:hint="@string/isOpen_placeIdHint"
+            android:hint="@string/isOpen_place_id_hint"
             android:imeOptions="actionGo"
             android:inputType="text"
             android:minHeight="48dp"
-            android:text="@string/isOpen_defaultPlaceId" />
+            android:text="@string/isOpen_default_place_id" />
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -50,7 +50,7 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:minHeight="48dp"
-                android:text="@string/isOpen_useCustomFieldsText" />
+                android:text="@string/isOpen_use_custom_fields_text" />
 
             <TextView
                 android:id="@+id/textView_custom_fields_list"
@@ -64,7 +64,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:minHeight="48dp"
-            android:text="@string/isOpen_useCustomTimeHint" />
+            android:text="@string/isOpen_use_custom_time_hint" />
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -77,7 +77,7 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="3"
                 android:minHeight="48dp"
-                android:text="@string/isOpen_spinnerDescription" />
+                android:text="@string/isOpen_spinner_description" />
 
             <Spinner
                 android:id="@+id/spinner_time_zones"
@@ -98,7 +98,7 @@
             android:cursorVisible="false"
             android:focusable="false"
             android:focusableInTouchMode="false"
-            android:hint="@string/isOpen_dateHint"
+            android:hint="@string/isOpen_date_hint"
             android:inputType="date"
             android:longClickable="false"
             android:minHeight="48dp" />
@@ -112,7 +112,7 @@
             android:cursorVisible="false"
             android:focusable="false"
             android:focusableInTouchMode="false"
-            android:hint="@string/isOpen_timeHint"
+            android:hint="@string/isOpen_time_hint"
             android:inputType="time"
             android:longClickable="false"
             android:minHeight="48dp" />
@@ -127,7 +127,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
-                android:text="@string/isOpen_fetchPlaceButtonText"
+                android:text="@string/isOpen_fetch_place_button_text"
                 tools:ignore="ButtonStyle" />
 
             <Button
@@ -135,7 +135,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
-                android:text="@string/isOpen_isOpenButtonText"
+                android:text="@string/isOpen_is_open_button_text"
                 tools:ignore="ButtonStyle" />
 
         </LinearLayout>

--- a/demo-kotlin/app/src/main/res/layout/place_is_open_activity.xml
+++ b/demo-kotlin/app/src/main/res/layout/place_is_open_activity.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+ Copyright 2020 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_margin="@dimen/spacing_large"
+    tools:context=".PlaceIsOpenActivity">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="10dp"
+        android:orientation="vertical">
+
+        <EditText
+            android:id="@+id/editText_placeId"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:autofillHints=""
+            android:hint="@string/isOpen_placeIdHint"
+            android:imeOptions="actionGo"
+            android:inputType="text"
+            android:minHeight="48dp"
+            android:text="@string/isOpen_defaultPlaceId" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <CheckBox
+                android:id="@+id/checkBox_use_custom_fields"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:minHeight="48dp"
+                android:text="@string/isOpen_useCustomFieldsText" />
+
+            <TextView
+                android:id="@+id/textView_custom_fields_list"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:weightSum="10">
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="3"
+                android:minHeight="48dp"
+                android:text="@string/isOpen_spinnerDescription" />
+
+            <Spinner
+                android:id="@+id/spinner_time_zones"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="7"
+                android:minHeight="48dp"
+                android:padding="10dp" />
+
+        </LinearLayout>
+
+        <EditText
+            android:id="@+id/editText_is_open_date"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:autofillHints=""
+            android:clickable="false"
+            android:cursorVisible="false"
+            android:focusable="false"
+            android:focusableInTouchMode="false"
+            android:hint="@string/isOpen_dateHint"
+            android:inputType="date"
+            android:longClickable="false"
+            android:minHeight="48dp" />
+
+        <EditText
+            android:id="@+id/editText_is_open_time"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:autofillHints=""
+            android:clickable="false"
+            android:cursorVisible="false"
+            android:focusable="false"
+            android:focusableInTouchMode="false"
+            android:hint="@string/isOpen_timeHint"
+            android:inputType="time"
+            android:longClickable="false"
+            android:minHeight="48dp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/button_fetchPlace"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/isOpen_fetchPlaceButtonText"
+                tools:ignore="ButtonStyle" />
+
+            <Button
+                android:id="@+id/button_isOpen"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/isOpen_isOpenButtonText"
+                tools:ignore="ButtonStyle" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <ProgressBar
+                android:id="@+id/progressBar_loading"
+                style="?android:attr/progressBarStyleSmall"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="invisible" />
+
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/textView_response"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:freezesText="true"
+            android:textIsSelectable="true" />
+
+    </LinearLayout>
+
+</ScrollView>

--- a/demo-kotlin/app/src/main/res/layout/place_is_open_activity.xml
+++ b/demo-kotlin/app/src/main/res/layout/place_is_open_activity.xml
@@ -60,6 +60,12 @@
 
         </LinearLayout>
 
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="48dp"
+            android:text="@string/isOpen_useCustomTimeHint" />
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/demo-kotlin/app/src/main/res/values/strings.xml
+++ b/demo-kotlin/app/src/main/res/values/strings.xml
@@ -153,7 +153,7 @@
 
   <string name="programmatic_autocomplete_geocoding">Programmatic Autocomplete + Geocoding</string>
   <string name="search">Search</string>
-  <string name="search_a_place">Search a Place</string>
+  <string name="search_a_place">Search for a Place</string>
   <string name="programmatic_place_predictions_instructions">This activity demonstrates as-you-type programmatic place predictions. Tap on the search icon on the toolbar and search for a place.</string>
 
   <!-- FIND CURRENT PLACE -->

--- a/demo-kotlin/app/src/main/res/values/strings.xml
+++ b/demo-kotlin/app/src/main/res/values/strings.xml
@@ -209,6 +209,5 @@
   <string name="isOpen_timeHint" translatable="false">Select isOpen time</string>
   <string name="isOpen_useCustomTimeHint" translatable="false">Use custom isOpen time? (must set time zone, date, and time)</string>
   <string name="isOpen_defaultPlaceId" translatable="false">ChIJD3uTd9hx5kcR1IQvGfr8dbk</string>
-  <string name="isOpen_resultDescription" translatable="false">Is Place Open?</string>
 
 </resources>

--- a/demo-kotlin/app/src/main/res/values/strings.xml
+++ b/demo-kotlin/app/src/main/res/values/strings.xml
@@ -41,11 +41,14 @@
   <!-- Button for launching autocomplete address form activity. -->
   <string name="autocomplete_address_button" translatable="false">Place Autocomplete Address Form</string>
 
+  <!-- Button for launching current place test activity. -->
+  <string name="current_place_button" translatable="false">Current Place</string>
+
   <!-- Button for launching place and photo test activity. -->
   <string name="place_and_photo_button" translatable="false">Place Details and Place Photos</string>
 
-  <!-- Button for launching current place test activity. -->
-  <string name="current_place_button" translatable="false">Current Place</string>
+  <!-- Button for launching is open test activity. -->
+  <string name="main_isOpenButtonText" translatable="false">Place is Open?</string>
 
 
   <!-- AUTOCOMPLETE -->
@@ -68,6 +71,9 @@
       Comma separated list of up to 5 place types
     </font>
   </string>
+
+  <!-- Text for the fetch autocomplete predictions submit button. -->
+  <string name="fetch_autocomplete_predictions_button" translatable="false">Fetch Predictions</string>
 
   <!-- AUTOCOMPLETE ADDRESS -->
 
@@ -100,16 +106,6 @@
 
   <!-- Text for the address form reset button. -->
   <string name="autocomplete_reset_button" translatable="false">Clear form</string>
-
-  <!-- KEEP UNTIL v3 REMOVED -->
-
-  <!-- Text for enabling autocomplete prediction's and widget's type filter field. -->
-  <string name="autocomplete_use_type_filter" translatable="false">Use TypeFilter? (Deprecated)</string>
-
-  <!-- Hint Text for the autocomplete prediction's and widget's type filter field. -->
-  <string name="autocomplete_type_filter" translatable="false">Type Filter</string>
-
-  <!-- END KEEP UNTIL v3 REMOVED -->
 
   <!-- Label for the autocomplete prediction's and widget's location origin field. -->
   <string name="autocomplete_location_origin_label" translatable="false">Location Origin (format: -33.2, 128.2)</string>
@@ -150,11 +146,33 @@
   <!-- Text for starting the autocomplete activity button. -->
   <string name="autocomplete_activity_button" translatable="false">Open Activity</string>
 
-  <!-- Text for the fetch autocomplete predictions submit button. -->
-  <string name="fetch_autocomplete_predictions_button" translatable="false">Fetch Predictions</string>
+  <!-- Text for the toast message for a skilled proximity match. -->
+  <string name="autocomplete_skipped_message" translatable="false">Address accepted without checking proximity</string>
 
+  <!-- PROGRAMMATIC AUTOCOMPLETE AND GEOCODING -->
 
-  <!-- FETCH PLACE AND PHOTO -->
+  <string name="programmatic_autocomplete_geocoding">Programmatic Autocomplete + Geocoding</string>
+  <string name="search">Search</string>
+  <string name="search_a_place">Search a Place</string>
+  <string name="programmatic_place_predictions_instructions">This activity demonstrates as-you-type programmatic place predictions. Tap on the search icon on the toolbar and search for a place.</string>
+
+  <!-- FIND CURRENT PLACE -->
+
+  <!-- Text for the find current place submit button. -->
+  <string name="find_current_place_button" translatable="false">Find Current Place</string>
+  <string name="icon_view_content_description" translatable="false">Icon View</string>
+  <string name="fetch_icon_checkbox" translatable="false">Also fetch icon?</string>
+  <string name="fetch_icon_missing_fields_warning" translatable="false">\'Also fetch icon?\' is selected, but ICON_URL Place Field is not.</string>
+  <string name="fetch_photo_selected_but_no_metadata">\'Also fetch photo?\' is selected, but PHOTO_METADATAS Place Field is not.</string>
+  <string name="custom_photo_reference_but_not_fetch_photo">Using \'Custom photo reference\', but \'Also fetch photo?\' is not selected.</string>
+  <string name="icon_view_image_content_description" translatable="false">Image view to display a Place Icon Image</string>
+  <string name="icon_with_background" translatable="false">Icon with background:</string>
+  <string name="place_photo" translatable="false">Place photo:</string>
+
+  <!-- PLACE DETAILS AND PHOTO -->
+
+  <!-- Place ID for a dining establishment, used as the default for testing in the Place and Photo screen -->
+  <string name="place_id_default" translatable="false">ChIJM3wn3VVYwokRvu2kbqBKUsM</string>
 
   <!-- Hint for the place ID field. -->
   <string name="place_id_field_hint" translatable="false">Enter place ID</string>
@@ -180,27 +198,17 @@
   <!-- Text for the fetch place and photo button. -->
   <string name="fetch_place_and_photo_button" translatable="false">Fetch Place and Photo</string>
 
-  <!-- Text for the toast message for a skilled proximity match. -->
-  <string name="autocomplete_skipped_message" translatable="false">Address accepted without checking proximity</string>
+  <!-- PLACE IS OPEN -->
 
-  <!-- FIND CURRENT PLACE -->
-
-  <!-- Text for the find current place submit button. -->
-  <string name="find_current_place_button" translatable="false">Find Current Place</string>
-  <string name="icon_view_content_description" translatable="false">Icon View</string>
-  <string name="fetch_icon_checkbox" translatable="false">Also fetch icon?</string>
-  <string name="fetch_icon_missing_fields_warning" translatable="false">\'Also fetch icon?\' is selected, but ICON_URL Place Field is not.</string>
-  <string name="fetch_photo_selected_but_no_metadata">\'Also fetch photo?\' is selected, but PHOTO_METADATAS Place Field is not.</string>
-  <string name="custom_photo_reference_but_not_fetch_photo">Using \'Custom photo reference\', but \'Also fetch photo?\' is not selected.</string>
-  <string name="icon_view_image_content_description" translatable="false">Image view to display a Place Icon Image</string>
-  <string name="icon_with_background" translatable="false">Icon with background:</string>
-  <string name="place_photo" translatable="false">Place photo:</string>
-  <!-- Place ID for SFO, used as the default for testing in the Place and Photo screen -->
-  <string name="place_id_SFO" translatable="false">ChIJVVVVVYx3j4ARP-3NGldc8qQ</string>
-
-  <string name="programmatic_autocomplete_geocoding">Programmatic Autocomplete + Geocoding</string>
-  <string name="search">Search</string>
-  <string name="search_a_place">Search a Place</string>
-  <string name="programmatic_place_predictions_instructions">This activity demonstrates as-you-type programmatic place predictions. Tap on the search icon on the toolbar and search for a place.</string>
+  <string name="isOpen_fetchPlaceButtonText" translatable="false">Fetch Place then check IsOpen</string>
+  <string name="isOpen_isOpenButtonText" translatable="false">Request IsOpen by Place ID</string>
+  <string name="isOpen_placeIdHint" translatable="false">Enter place ID</string>
+  <string name="isOpen_useCustomFieldsText" translatable="false">Manually set Place Fields?</string>
+  <string name="isOpen_spinnerDescription" translatable="false">Time Zone</string>
+  <string name="isOpen_dateHint" translatable="false">Select isOpen date</string>
+  <string name="isOpen_timeHint" translatable="false">Select isOpen time</string>
+  <string name="isOpen_useCustomTimeHint" translatable="false">Use custom isOpen time? (must set time zone, date, and time)</string>
+  <string name="isOpen_defaultPlaceId" translatable="false">ChIJD3uTd9hx5kcR1IQvGfr8dbk</string>
+  <string name="isOpen_resultDescription" translatable="false">Is Place Open?</string>
 
 </resources>

--- a/demo-kotlin/app/src/main/res/values/strings.xml
+++ b/demo-kotlin/app/src/main/res/values/strings.xml
@@ -200,14 +200,14 @@
 
   <!-- PLACE IS OPEN -->
 
-  <string name="isOpen_fetchPlaceButtonText" translatable="false">Fetch Place then check IsOpen</string>
-  <string name="isOpen_isOpenButtonText" translatable="false">Request IsOpen by Place ID</string>
-  <string name="isOpen_placeIdHint" translatable="false">Enter place ID</string>
-  <string name="isOpen_useCustomFieldsText" translatable="false">Manually set Place Fields?</string>
-  <string name="isOpen_spinnerDescription" translatable="false">Time Zone</string>
-  <string name="isOpen_dateHint" translatable="false">Select isOpen date</string>
-  <string name="isOpen_timeHint" translatable="false">Select isOpen time</string>
-  <string name="isOpen_useCustomTimeHint" translatable="false">Use custom isOpen time? (must set time zone, date, and time)</string>
-  <string name="isOpen_defaultPlaceId" translatable="false">ChIJD3uTd9hx5kcR1IQvGfr8dbk</string>
+  <string name="isOpen_fetch_place_button_text" translatable="false">Fetch Place then check IsOpen</string>
+  <string name="isOpen_is_open_button_text" translatable="false">Request IsOpen by Place ID</string>
+  <string name="isOpen_place_id_hint" translatable="false">Enter place ID</string>
+  <string name="isOpen_use_custom_fields_text" translatable="false">Manually set Place Fields?</string>
+  <string name="isOpen_spinner_description" translatable="false">Time Zone</string>
+  <string name="isOpen_date_hint" translatable="false">Select isOpen date</string>
+  <string name="isOpen_time_hint" translatable="false">Select isOpen time</string>
+  <string name="isOpen_use_custom_time_hint" translatable="false">Use custom isOpen time? (must set time zone, date, and time)</string>
+  <string name="isOpen_default_place_id" translatable="false">ChIJD3uTd9hx5kcR1IQvGfr8dbk</string>
 
 </resources>

--- a/demo-kotlin/build.gradle
+++ b/demo-kotlin/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:8.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.1"
     }

--- a/demo-kotlin/build.gradle
+++ b/demo-kotlin/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.8.21'
 
     repositories {
         google()
@@ -18,9 +18,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        flatDir {
-            dirs 'libs'
-        }
     }
 }
 

--- a/demo-kotlin/gradle.properties
+++ b/demo-kotlin/gradle.properties
@@ -17,3 +17,6 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/demo-kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/demo-kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Mar 28 15:44:27 PDT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/snippets/app/build.gradle
+++ b/snippets/app/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdk 33
@@ -21,9 +20,14 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
+    buildFeatures {
+        viewBinding = true
+    }
+
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     namespace 'com.google.places'
 }
@@ -33,17 +37,17 @@ dependencies {
     // [START_EXCLUDE silent]
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'androidx.core:core-ktx:1.10.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'com.android.volley:volley:1.2.1'
     implementation "com.github.bumptech.glide:glide:4.13.2"
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     // [END_EXCLUDE]
     // [START maps_android_places_upgrade_snippet]
-    implementation 'com.google.android.libraries.places:places:3.0.0'
+    implementation 'com.google.android.libraries.places:places:3.1.0'
     // [END maps_android_places_upgrade_snippet]
 }
 // [END maps_android_places_install_snippet]

--- a/snippets/app/src/main/AndroidManifest.xml
+++ b/snippets/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
         android:allowBackup="true"

--- a/snippets/app/src/main/java/com/google/places/kotlin/PlaceAutocompleteActivity.kt
+++ b/snippets/app/src/main/java/com/google/places/kotlin/PlaceAutocompleteActivity.kt
@@ -15,9 +15,10 @@
 package com.google.places.kotlin
 
 import android.app.Activity
-import android.content.Intent
 import android.os.Bundle
 import android.util.Log
+import androidx.activity.result.ActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.common.api.Status
@@ -31,12 +32,10 @@ import com.google.android.libraries.places.api.net.FindAutocompletePredictionsRe
 import com.google.android.libraries.places.api.net.FindAutocompletePredictionsResponse
 import com.google.android.libraries.places.api.net.PlacesClient
 import com.google.android.libraries.places.widget.Autocomplete
-import com.google.android.libraries.places.widget.AutocompleteActivity
 import com.google.android.libraries.places.widget.AutocompleteSupportFragment
 import com.google.android.libraries.places.widget.listener.PlaceSelectionListener
 import com.google.android.libraries.places.widget.model.AutocompleteActivityMode
 import com.google.places.R
-import java.util.*
 
 class PlaceAutocompleteActivity : AppCompatActivity() {
     private lateinit var placesClient: PlacesClient
@@ -60,7 +59,7 @@ class PlaceAutocompleteActivity : AppCompatActivity() {
         // Initialize the AutocompleteSupportFragment.
         val autocompleteFragment =
             supportFragmentManager.findFragmentById(R.id.autocomplete_fragment)
-                as AutocompleteSupportFragment
+                    as AutocompleteSupportFragment
 
         // Specify the types of place data to return.
         autocompleteFragment.setPlaceFields(listOf(Place.Field.ID, Place.Field.NAME))
@@ -110,7 +109,6 @@ class PlaceAutocompleteActivity : AppCompatActivity() {
         val intent = Autocomplete.IntentBuilder(AutocompleteActivityMode.FULLSCREEN, fields)
             .setTypesFilter(listOf(TypeFilter.ADDRESS.toString()))
             .build(this)
-        startActivityForResult(intent, AUTOCOMPLETE_REQUEST_CODE)
         // [END maps_places_intent_type_filter]
 
         // [START maps_places_autocomplete_country_filter]
@@ -119,11 +117,10 @@ class PlaceAutocompleteActivity : AppCompatActivity() {
     }
 
     // [START maps_places_autocomplete_intent]
-        private val AUTOCOMPLETE_REQUEST_CODE = 1
 
     // [START_EXCLUDE silent]
     private fun startAutocompleteIntent() {
-    // [END_EXCLUDE]
+        // [END_EXCLUDE]
         // Set the fields to specify which types of place data to
         // return after the user has made a selection.
         val fields = listOf(Place.Field.ID, Place.Field.NAME)
@@ -131,35 +128,26 @@ class PlaceAutocompleteActivity : AppCompatActivity() {
         // Start the autocomplete intent.
         val intent = Autocomplete.IntentBuilder(AutocompleteActivityMode.FULLSCREEN, fields)
             .build(this)
-        startActivityForResult(intent, AUTOCOMPLETE_REQUEST_CODE)
+        startAutocomplete.launch(intent)
         // [END maps_places_autocomplete_intent]
     }
 
     // [START maps_places_on_activity_result]
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        if (requestCode == AUTOCOMPLETE_REQUEST_CODE) {
-            when (resultCode) {
-                Activity.RESULT_OK -> {
-                    data?.let {
-                        val place = Autocomplete.getPlaceFromIntent(data)
-                        Log.i(TAG, "Place: ${place.name}, ${place.id}")
-                    }
+    private val startAutocomplete =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
+            if (result.resultCode == Activity.RESULT_OK) {
+                val intent = result.data
+                if (intent != null) {
+                    val place = Autocomplete.getPlaceFromIntent(intent)
+                    Log.i(
+                        TAG, "Place: {\$place.getName()}, \${place.getId()}"
+                    )
                 }
-                AutocompleteActivity.RESULT_ERROR -> {
-                    // TODO: Handle the error.
-                    data?.let {
-                        val status = Autocomplete.getStatusFromIntent(data)
-                        Log.i(TAG, status.statusMessage ?: "")
-                    }
-                }
-                Activity.RESULT_CANCELED -> {
-                    // The user canceled the operation.
-                }
+            } else if (result.resultCode == Activity.RESULT_CANCELED) {
+                // The user canceled the operation.
+                Log.i(TAG, "User canceled autocomplete")
             }
-            return
         }
-        super.onActivityResult(requestCode, resultCode, data)
-    }
     // [END maps_places_on_activity_result]
 
     private fun programmaticPlacePredictions(query: String) {
@@ -193,13 +181,13 @@ class PlaceAutocompleteActivity : AppCompatActivity() {
                 }
             }.addOnFailureListener { exception: Exception? ->
                 if (exception is ApiException) {
-                    Log.e(TAG, "Place not found: " + exception.statusCode)
+                    Log.e(TAG, "Place not found: ${exception.statusCode}")
                 }
             }
         // [END maps_places_programmatic_place_predictions]
     }
 
     companion object {
-        val TAG = PlaceAutocompleteActivity.javaClass.simpleName
+        val TAG = PlaceAutocompleteActivity::class.java.simpleName
     }
 }

--- a/snippets/build.gradle
+++ b/snippets/build.gradle
@@ -1,12 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.7.21"
+    ext.kotlin_version = "1.8.21"
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:8.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/snippets/gradle.properties
+++ b/snippets/gradle.properties
@@ -19,3 +19,6 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/snippets/gradle/wrapper/gradle-wrapper.properties
+++ b/snippets/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip


### PR DESCRIPTION
- Add isOpen samples for Kotlin and Java
- Refactor display text in Place Details and Photo sample
- Use different default Place IDs to better demonstrate new Place data fields
- Remove unsupported data fields from Current Place demo
- Replace deprecated `setCountry` with `setCountries`

Fixes #522