### PR TITLE
refactor: Update Places SDK usage and apply lint improvements

### DIFF
--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/CurrentPlaceActivity.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/CurrentPlaceActivity.kt
@@ -23,7 +23,6 @@ import android.view.View
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresPermission
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import com.example.placesdemo.databinding.CurrentPlaceActivityBinding
 import com.google.android.libraries.places.api.Places

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/FieldSelector.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/FieldSelector.kt
@@ -30,7 +30,7 @@ import androidx.appcompat.app.AlertDialog
 import com.google.android.libraries.places.api.model.Place
 import java.util.*
 
-/** Helper class for selecting [Field] values.  */
+/** Helper class for selecting [Place.Field] values.  */
 class FieldSelector(
     enableView: CheckBox,
     outputView: TextView,
@@ -42,7 +42,7 @@ class FieldSelector(
     private val outputView: TextView
 
     /**
-     * Shows dialog to allow user to select [Field] values they want.
+     * Shows dialog to allow user to select [Place.Field] values they want.
      */
     private fun showDialog(context: Context?) {
         val listView = ListView(context)
@@ -59,13 +59,13 @@ class FieldSelector(
     }
 
     /**
-     * Returns all [Field] that are selectable.
+     * Returns all [Place.Field] that are selectable.
      */
     val allFields: List<Place.Field>
         get() = ArrayList(fieldStates.keys)
 
     /**
-     * Returns all [Field] values the user selected.
+     * Returns all [Place.Field] values the user selected.
      */
     val selectedFields: List<Place.Field>
         get() {
@@ -79,7 +79,7 @@ class FieldSelector(
         }
 
     /**
-     * Returns a String representation of all selected [Field] values. See [ ][.getSelectedFields].
+     * Returns a String representation of all selected [Place.Field] values. See [ ][.getSelectedFields].
      */
     val selectedString: String
         get() {
@@ -153,15 +153,14 @@ class FieldSelector(
         private const val SELECTED_PLACE_FIELDS_KEY = "selected_place_fields"
 
         /**
-         * Returns all [Field] values except those passed in.
-         *
-         *
-         * Convenience method for when most [Field] values are desired. Useful for APIs that do
-         * no support all [Field] values.
+         * Returns all [Place.Field] values except those passed in.
+         * <p>
+         * Convenience method for when most [Place.Field] values are desired. Useful for APIs that do
+         * no support all [Place.Field] values.
          */
         fun allExcept(vararg placeFieldsToOmit: Place.Field): List<Place.Field> {
             // Arrays.asList is immutable, create a mutable list to allow removing fields
-            val placeFields: MutableList<Place.Field> = ArrayList(Arrays.asList(*Place.Field.values()))
+            val placeFields: MutableList<Place.Field> = ArrayList(listOf(*Place.Field.entries.toTypedArray()))
             placeFields.removeAll(placeFieldsToOmit)
             return placeFields
         }

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/MainActivity.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/MainActivity.kt
@@ -18,8 +18,6 @@ package com.example.placesdemo
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuItem
 import android.widget.Button
 import com.example.placesdemo.databinding.ActivityMainBinding
 import com.example.placesdemo.programmatic_autocomplete.ProgrammaticAutocompleteGeocodingActivity

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/PlaceAutocompleteActivity.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/PlaceAutocompleteActivity.kt
@@ -137,7 +137,7 @@ class PlaceAutocompleteActivity : BaseActivity() {
     private var autocompleteLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
         result ->
         when (result.resultCode) {
-            AutocompleteActivity.RESULT_OK -> {
+            RESULT_OK -> {
                 val data: Intent? = result.data
                 if (data != null) {
                     val place = Autocomplete.getPlaceFromIntent(data)
@@ -149,7 +149,7 @@ class PlaceAutocompleteActivity : BaseActivity() {
                 val status = Autocomplete.getStatusFromIntent(intent)
                 binding.response.text = status.statusMessage
             }
-            AutocompleteActivity.RESULT_CANCELED -> {
+            RESULT_CANCELED -> {
                 // The user canceled the operation.
             }
         }

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/PlaceDetailsAndPhotosActivity.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/PlaceDetailsAndPhotosActivity.kt
@@ -15,7 +15,7 @@
  */
 package com.example.placesdemo
 
-import android.content.Context
+import android.graphics.Bitmap
 import android.os.Bundle
 import android.text.TextUtils
 import android.view.View
@@ -61,8 +61,9 @@ class PlaceDetailsAndPhotosActivity : BaseActivity() {
 
         // Retrieve a PlacesClient (previously initialized - see MainActivity)
         placesClient = Places.createClient(this)
-        if (savedInstanceState != null && savedInstanceState.containsKey(FETCHED_PHOTO_KEY)) {
-            photo = savedInstanceState.getParcelable(FETCHED_PHOTO_KEY)
+        // Restore photo from saved instance state if it exists
+        savedInstanceState?.getParcelable<PhotoMetadata>(FETCHED_PHOTO_KEY)?.let { savedPhoto ->
+            photo = savedPhoto
         }
 
         binding.fetchPhotoCheckbox.setOnCheckedChangeListener { _, isChecked: Boolean ->
@@ -148,7 +149,7 @@ class PlaceDetailsAndPhotosActivity : BaseActivity() {
     private fun attemptFetchIcon(place: Place) {
         binding.icon.setImageBitmap(null)
         place.iconBackgroundColor?.let { binding.icon.setBackgroundColor(it) }
-        val url = place.iconUrl
+        val url = place.iconMaskUrl
         Glide.with(this).load(url).into(binding.icon)
     }
 
@@ -192,7 +193,7 @@ class PlaceDetailsAndPhotosActivity : BaseActivity() {
     // Helper methods below //
     //////////////////////////
     private fun dismissKeyboard(focusedEditText: EditText) {
-        val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        val imm = getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
         imm.hideSoftInputFromWindow(focusedEditText.windowToken, 0)
     }
 

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/PlaceIsOpenActivity.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/PlaceIsOpenActivity.kt
@@ -18,7 +18,6 @@ package com.example.placesdemo
 import android.annotation.SuppressLint
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
-import android.content.Context
 import android.os.Bundle
 import android.view.View
 import android.view.inputmethod.InputMethodManager
@@ -37,7 +36,9 @@ import com.google.android.libraries.places.api.net.PlacesClient
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
-import java.util.TimeZone.*
+import java.util.TimeZone.getAvailableIDs
+import java.util.TimeZone.getDefault
+import java.util.TimeZone.getTimeZone
 
 /**
  * Activity to demonstrate [PlacesClient.isOpen].
@@ -178,7 +179,7 @@ class PlaceIsOpenActivity : BaseActivity() {
     //////////////////////////
     private fun dismissKeyboard(focusedEditText: EditText) {
         val imm: InputMethodManager =
-            getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+            getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
         imm.hideSoftInputFromWindow(focusedEditText.windowToken, 0)
     }
 

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/StringUtil.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/StringUtil.kt
@@ -25,7 +25,6 @@ import com.google.android.libraries.places.api.model.Place
 import com.google.android.libraries.places.api.net.FetchPlaceResponse
 import com.google.android.libraries.places.api.net.FindAutocompletePredictionsResponse
 import com.google.android.libraries.places.api.net.FindCurrentPlaceResponse
-import java.util.*
 
 /**
  * Utility class for converting objects to viewable strings and back.
@@ -61,9 +60,9 @@ object StringUtil {
             null
         } else try {
             LatLng(split[0].toDouble(), split[1].toDouble())
-        } catch (e: NullPointerException) {
+        } catch (_: NullPointerException) {
             null
-        } catch (e: NumberFormatException) {
+        } catch (_: NumberFormatException) {
             null
         }
     }
@@ -125,7 +124,7 @@ object StringUtil {
     }
 
     fun stringify(place: Place): String {
-        return "${place.name?.plus(" (") ?: ""}${place.address?.plus(")") ?: ""}"
+        return "${place.displayName?.plus(" (") ?: ""}${place.formattedAddress?.plus(")") ?: ""}"
     }
 
     fun stringify(bitmap: Bitmap): String {

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/model/AutocompleteEditText.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/model/AutocompleteEditText.kt
@@ -20,11 +20,10 @@ import android.view.MotionEvent
 import androidx.appcompat.widget.AppCompatEditText
 
 class AutocompleteEditText : AppCompatEditText {
-    constructor(context: Context?) : super(context!!) {}
+    constructor(context: Context?) : super(context!!)
     constructor(context: Context?, attrs: AttributeSet?) : super(
         context!!, attrs
-    ) {
-    }
+    )
 
     override fun onTouchEvent(event: MotionEvent): Boolean {
         super.onTouchEvent(event)

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/model/GeocodingResult.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/model/GeocodingResult.kt
@@ -15,7 +15,6 @@
 package com.example.placesdemo.model
 
 import java.io.Serializable
-import java.util.*
 
 class GeocodingResult : Serializable {
     /**
@@ -77,9 +76,9 @@ class GeocodingResult : Serializable {
         sb.append(" placeId=").append(placeId)
         sb.append(" ").append(geometry)
         sb.append(", formattedAddress=").append(formattedAddress)
-        sb.append(", types=").append(Arrays.toString(types))
-        if (postcodeLocalities != null && postcodeLocalities!!.size > 0) {
-            sb.append(", postcodeLocalities=").append(Arrays.toString(postcodeLocalities))
+        sb.append(", types=").append(types.contentToString())
+        if (postcodeLocalities != null && postcodeLocalities!!.isNotEmpty()) {
+            sb.append(", postcodeLocalities=").append(postcodeLocalities.contentToString())
         }
         sb.append("]")
         return sb.toString()

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/programmatic_autocomplete/PlacePredictionAdapter.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/programmatic_autocomplete/PlacePredictionAdapter.kt
@@ -51,9 +51,11 @@ class PlacePredictionAdapter : RecyclerView.Adapter<PlacePredictionViewHolder>()
     }
 
     fun setPredictions(predictions: List<AutocompletePrediction>?) {
-        this.predictions.clear()
-        this.predictions.addAll(predictions!!)
-        notifyDataSetChanged()
+        if (predictions != null) {
+            this.predictions.clear()
+            this.predictions.addAll(predictions)
+            notifyDataSetChanged()
+        }
     }
 
     class PlacePredictionViewHolder(itemView: View) : ViewHolder(itemView) {

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/programmatic_autocomplete/ProgrammaticAutocompleteGeocodingActivity.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/programmatic_autocomplete/ProgrammaticAutocompleteGeocodingActivity.kt
@@ -114,7 +114,7 @@ class ProgrammaticAutocompleteGeocodingActivity : BaseActivity() {
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.menu, menu)
         val searchView =
-            menu.findItem(R.id.search).actionView as com.google.android.material.search.SearchView
+            menu.findItem(R.id.search).actionView as SearchView
         initSearchView(searchView)
         return super.onCreateOptionsMenu(menu)
     }
@@ -277,18 +277,17 @@ class ProgrammaticAutocompleteGeocodingActivity : BaseActivity() {
             .addOnSuccessListener { response: FetchPlaceResponse ->
                 val place = response.place
                 AlertDialog.Builder(this)
-                    .setTitle(place.name)
-                    .setMessage("located at:\n" + place.address)
+                    .setTitle(place.displayName)
+                    .setMessage("located at:\n" + place.formattedAddress)
                     .setPositiveButton(android.R.string.ok, null)
                     .show()
-                Log.i(TAG, "Place found: ${place.name}")
+                Log.i(TAG, "Place found: ${place.displayName}")
             }.addOnFailureListener { exception: Exception ->
                 if (exception is ApiException) {
                     Log.e(TAG, "Place not found: ${exception.message} ${exception.statusCode}")
                 }
             }
     }
-
 
     companion object {
         private val TAG = ProgrammaticAutocompleteGeocodingActivity::class.java.simpleName

--- a/demo-kotlin/app/src/main/res/layout/autocomplete_address_map.xml
+++ b/demo-kotlin/app/src/main/res/layout/autocomplete_address_map.xml
@@ -28,7 +28,7 @@
     <!-- A map will be added here programmatically
     for visual confirmation of the selected address -->
     <!-- [START maps_solutions_android_autocomplete_map_fragment] -->
-    <fragment xmlns:android="http://schemas.android.com/apk/res/android"
+    <fragment
         android:name="com.google.android.gms.maps.SupportMapFragment"
         android:id="@+id/confirmation_map"
         android:layout_width="match_parent"


### PR DESCRIPTION
This commit updates the Kotlin demo application to use modern Places SDK APIs and incorporates various code quality improvements.

Key changes include:
- **Places API Migration**:
  - Replaced deprecated `Place.name` with `Place.displayName`.
  - Replaced deprecated `Place.address` with `Place.formattedAddress`.
  - Replaced deprecated `Place.iconUrl` with `Place.iconMaskUrl`. These changes affect how place information is displayed in the programmatic autocomplete and place details screens.

- **Kotlin Modernization & Lint Fixes**:
  - Migrated from `Enum.values()` to the recommended `Enum.entries` in `FieldSelector`.
  - Replaced `Arrays.toString()` with the idiomatic `contentToString()` for logging arrays in `GeocodingResult`.
  - Improved null safety by adding explicit null checks, such as in `PlacePredictionAdapter`.
  - Removed numerous unused imports and redundant code across multiple files.
  - Adopted modern `getSystemService(CONSTANT)` syntax.
  - Cleaned up minor code style issues.
