### PR TITLE
fix: update kotlin and resolve maps utils compilation crash

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,3 +25,11 @@ plugins {
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.kotlin.kapt) apply false
 }
+
+allprojects {
+    configurations.all {
+        resolutionStrategy {
+            force("org.jetbrains.kotlin:kotlin-metadata-jvm:2.3.10")
+        }
+    }
+}

--- a/demo-kotlin/build.gradle.kts
+++ b/demo-kotlin/build.gradle.kts
@@ -42,7 +42,8 @@ android {
         compilerOptions {
             freeCompilerArgs.addAll(
                 "-opt-in=kotlin.RequiresOptIn",
-                "-Xannotation-default-target=param-property"
+                "-Xannotation-default-target=param-property",
+                "-Xskip-metadata-version-check"
             )
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.13.2"
-kotlin = "2.1.10"
+kotlin = "2.3.10"
 coreKtx = "1.17.0"
 appcompat = "1.7.1"
 activity = "1.12.4"
@@ -15,10 +15,10 @@ materialIconsExtended = "1.7.8"
 googleMaps = "20.0.0"
 places = "5.1.1"
 playServicesLocation = "21.3.0"
-mapsCompose = "6.12.2"
-mapsUtilsKtx = "5.2.1"
-androidMapsUtils = "4.1.0"
-playServicesMaps3d = "0.0.2"
+mapsCompose = "8.2.2"
+mapsUtilsKtx = "6.0.1"
+androidMapsUtils = "4.1.1"
+playServicesMaps3d = "0.2.0"
 volley = "1.2.1"
 glide = "5.0.5"
 navigationFragment = "2.9.5"
@@ -31,13 +31,14 @@ junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
 testRules = "1.7.0"
-ksp = "2.1.10-1.0.29"
-kotlinParcelize = "2.1.10"
+ksp = "2.3.6"
+kotlinParcelize = "2.3.10"
 mapsSecretsGradlePlugin = "2.0.1"
 
 [libraries]
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
+kotlin-metadata-jvm = { group = "org.jetbrains.kotlin", name = "kotlin-metadata-jvm", version.ref = "kotlin" }
 secrets-gradlePlugin = { group = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", name = "secrets-gradle-plugin", version.ref = "mapsSecretsGradlePlugin" }
 
 # Core Android & Kotlin


### PR DESCRIPTION
## Description

Updates Kotlin to support newer Maps Utils dependencies and resolves a K2 compiler crash (`java.lang.IllegalArgumentException: source must not be null`) encountered when consuming Kotlin `2.3.0` metadata while on an older Kotlin version.

### Changes
* **Kotlin**: Upgraded to `2.3.10`
* **KSP**: Upgraded to `2.3.6`
* **Maps Utils**: Validated stability of `android-maps-utils:4.1.1` and `maps-utils-ktx:6.0.1` with the new Kotlin version.
* **Hilt Fix**: Added `org.jetbrains.kotlin:kotlin-metadata-jvm:2.3.10` via resolution strategy to fix a Hilt annotation processing error caused by the Kotlin upgrade.
* **Compiler Flags**: Added `-Xskip-metadata-version-check` to the `:demo-kotlin` module.

### Motivation
Upgrading the underlying Google Maps Utilities.