### PR TITLE
chore(deps): bump github actions to latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,13 +32,13 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v5.2.0
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       - name: Install NDK
         run: |
@@ -56,7 +56,7 @@ jobs:
 
       - name: Upload build reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: build-reports
           path: "**/build/reports"


### PR DESCRIPTION
## Summary

- `actions/checkout`: `v4` → `v4.2.2` (pinned to specific patch)
- `actions/setup-java`: `v4.2.1` → `v5.2.0`, `distribution: adopt` → `distribution: temurin` — **breaking**: AdoptOpenJDK is deprecated and no longer receives updates; Eclipse Temurin is the maintained successor
- `actions/upload-artifact`: `v4` → `v4.6.2` (pinned to specific patch; staying on v4 to avoid v5+ hidden-files behavior changes)

## Test plan

- [ ] Verify the build CI job runs successfully on this PR
- [ ] Confirm JDK 17 setup works correctly with `temurin` distribution
- [ ] Check build reports artifact is uploaded as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)